### PR TITLE
fix(nix): set pnpm's fetcherVersion to a supported value

### DIFF
--- a/nix/assets.nix
+++ b/nix/assets.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   pnpmDeps = pnpm.fetchDeps {
     inherit src version pname;
     hash = "sha256-nDSltpFQRM9loVuDour4OrRdN22/A7MkZTGAtL0x7rU=";
-    fetcherVersion = 9;
+    fetcherVersion = 2;
   };
   nativeBuildInputs = [
     pnpm.configHook

--- a/nix/typescript/shims.nix
+++ b/nix/typescript/shims.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     inherit src version pname;
     #TODO: automatic hash update
     hash = "sha256-LofHepVz6CjbAXkUwwNFVzlbmPq+g/gJvkBka9I/gHo=";
-    fetcherVersion = 9;
+    fetcherVersion = 2;
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
The fetcherVersion set for pnpm.fetchDeps is unsupported, which results in a build failure.

See https://github.com/NixOS/nixpkgs/pull/427828 for details about this change.