### PR TITLE
Fix steamwebhelper crash when opening Chrome Web Store

### DIFF
--- a/src/core/http_hooks.cc
+++ b/src/core/http_hooks.cc
@@ -177,7 +177,10 @@ static const std::unordered_set<std::string> g_doNotHook = {
 
     /** Ignore youtube related content */
     R"(https?://(?:[\w-]+\.)*(?:youtube(?:-nocookie)?|youtu|ytimg|googlevideo|googleusercontent|studioyoutube)\.com/[^\s"']*)",
-    R"(https?://(?:[\w-]+\.)*youtu\.be/[^\s"']*)"
+    R"(https?://(?:[\w-]+\.)*youtu\.be/[^\s"']*)",
+
+    /** Ignore Chrome Web Store (causes a webhelper crash on Fetch.fulfillRequest) */
+    R"(https?:\/\/(?:[\w-]+\.)*chromewebstore\.google\.com\/[^\s"']*)",
 };
 // clang-format on
 


### PR DESCRIPTION
When you open https://chromewebstore.google.com/ in the Steam browser with Millennium loaded, steamwebhelper.exe immediately crashes. This PR resolves the issue by excluding the page from the HTTP hooks.
To test the issue, drag and drop the above link to the store page in the main window, or open that URL in the overlay browser. I confirmed this behavior on Windows 10 and 11.

After tinkering with the code, I found that sending the `Fetch.fulfillRequest` message causes the crash. I'm guessing that this is caused by internal conflict with the DevTools Fetch API and the internal Chrome extension that enables private API access for the web store (`chrome-extension://ahfgeienlihckogmohjhadlkjgocpleb`).