### PR TITLE
replace deprecated prev.system

### DIFF
--- a/packages/nix/flake.nix
+++ b/packages/nix/flake.nix
@@ -52,19 +52,39 @@
     {
       packages.x86_64-linux =
         let
-          pkgs = import nixpkgs { system = "x86_64-linux"; config.allowUnfree = true; };
+          pkgs = import nixpkgs {
+            system = "x86_64-linux";
+            config.allowUnfree = true;
+          };
           packages = {
             default = packages.millennium-steam;
-            millennium-python   = pkgs.callPackage ./python.nix             { };
-            millennium-assets   = pkgs.callPackage ./assets.nix             { inherit millennium-src; };
-            millennium-frontend = pkgs.callPackage ./frontend.nix           { inherit millennium-src; };
-            millennium-shims    = pkgs.callPackage ./shims.nix              { inherit millennium-src; };
-            millennium          = pkgs.callPackage ./millennium.nix         { inherit (packages) millennium-python millennium-shims millennium-assets millennium-frontend; inherit inputs; };
-            millennium-steam    = pkgs.callPackage ./steam.nix              { inherit (packages) millennium-python millennium-shims millennium-assets millennium; };
+            millennium-python = pkgs.callPackage ./python.nix { };
+            millennium-assets = pkgs.callPackage ./assets.nix { inherit millennium-src; };
+            millennium-frontend = pkgs.callPackage ./frontend.nix { inherit millennium-src; };
+            millennium-shims = pkgs.callPackage ./shims.nix { inherit millennium-src; };
+            millennium = pkgs.callPackage ./millennium.nix {
+              inherit (packages)
+                millennium-python
+                millennium-shims
+                millennium-assets
+                millennium-frontend
+                ;
+              inherit inputs;
+            };
+            millennium-steam = pkgs.callPackage ./steam.nix {
+              inherit (packages)
+                millennium-python
+                millennium-shims
+                millennium-assets
+                millennium
+                ;
+            };
           };
         in
         packages;
 
-      overlays.default = final: prev: { inherit (self.packages.${prev.system}) millennium-steam; };
+      overlays.default = final: prev: {
+        inherit (self.packages.${prev.stdenv.hostPlatform.system}) millennium-steam;
+      };
     };
 }


### PR DESCRIPTION
system as referenced in `inherit (self.packages.${prev.system}`, is deprecated which results in these warnings when rebuilding:
`evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`

This renames it to the proper name which is now `stdenv.hostPlatform.system` inside the `flake.nix`. Testing on my local appears to have made the error go away.

Other changes were due to my `prettierd` adjusting the formatting to be in line with the `nixfmt` standard. If this is unwanted, then it can be reverted, but I think it makes it more legible than it was before