### PR TITLE
fix(theme): prevent repeated update prompt after theme update and restart

### DIFF
--- a/src/backend/entry_point.cc
+++ b/src/backend/entry_point.cc
@@ -135,6 +135,7 @@ IPC_RET(Core_SetBackendConfig, CONFIG.SetAll(nlohmann::json::parse(ARGS["config"
 
 /** Theme and Plugin update API */
 IPC_RET(Core_GetUpdates, updater->CheckForUpdates(ARGS.value("force", false)).value_or(nullptr))
+IPC_NIL(Core_ResetUpdateCheckState, updater->ResetCheckState())
 
 /** Theme manager API */
 IPC_RET(Core_GetActiveTheme, themeConfig->GetActiveTheme())

--- a/src/backend/library_updater.cc
+++ b/src/backend/library_updater.cc
@@ -65,6 +65,12 @@ bool Updater::HasCheckedForUpdates() const
     return has_checked_for_updates;
 }
 
+void Updater::ResetCheckState()
+{
+    has_checked_for_updates = false;
+    cached_updates = std::nullopt;
+}
+
 std::optional<json> Updater::CheckForUpdates(bool force)
 {
     try {

--- a/src/backend/theme_mgr.cc
+++ b/src/backend/theme_mgr.cc
@@ -324,7 +324,13 @@ bool ThemeInstaller::UpdateTheme(std::shared_ptr<ThemeConfig> themeConfig, const
 #ifdef __linux__
 #pragma GCC diagnostic pop
 #endif
-        git_remote_fetch(remote, nullptr, &fetch_opts, nullptr);
+        if (git_remote_fetch(remote, nullptr, &fetch_opts, nullptr) != 0) {
+            git_remote_free(remote);
+            git_repository_free(repo);
+            Logger.Log("Failed to fetch from remote 'origin' for repo: {}", path.string());
+            git_libgit2_shutdown();
+            return false;
+        }
 
         git_object* obj = nullptr;
         if (git_revparse_single(&obj, repo, "refs/remotes/origin/HEAD") != 0) {

--- a/src/frontend/settings/updates/ThemeUpdateCards.tsx
+++ b/src/frontend/settings/updates/ThemeUpdateCards.tsx
@@ -33,7 +33,7 @@ import { SettingsDialogSubHeader } from '../../components/SteamComponents';
 import { formatString, locale, SteamLocale } from '../../utils/localization-manager';
 import { UpdateCard, UpdateItemType } from './UpdateCard';
 import { UpdateContextProviderState, useUpdateContext } from './useUpdateContext';
-import { PyUpdateTheme } from '../../utils/ffi';
+import { PyUpdateTheme, PyResetUpdateCheckState } from '../../utils/ffi';
 import { ThemeItem } from '../../types';
 import { Utils } from '../../utils';
 import { produce } from 'immer';
@@ -70,6 +70,9 @@ async function StartThemeUpdate(ctx: UpdateContextProviderState, setUpdateState:
 			uxSleepLength: 1000,
 		});
 
+		// Reset the update check state to force a fresh check on next startup
+		// This prevents the theme from showing as needing an update after restart
+		await PyResetUpdateCheckState();
 		await fetchAvailableUpdates(true);
 		const activeTheme: ThemeItem = pluginSelf.activeTheme;
 

--- a/src/frontend/utils/ffi.ts
+++ b/src/frontend/utils/ffi.ts
@@ -43,6 +43,7 @@ export const PyUninstallPlugin = callable<[{ pluginName: string }], boolean>('Co
 export const PyUpdateTheme = callable<[{ native: string }], boolean>('Core_DownloadThemeUpdate');
 export const PyUpdatePlugin = callable<[{ id: string; name: string }], boolean>('Core_DownloadPluginUpdate');
 export const PyResyncUpdates = callable<[{ force: boolean }], string>('Core_GetUpdates');
+export const PyResetUpdateCheckState = callable<[], void>('Core_ResetUpdateCheckState');
 export const PyInstallPlugin = callable<[{ download_url: string; total_size: number }], void>('Core_InstallPlugin');
 export const PyIsPluginInstalled = callable<[{ plugin_name: string }], boolean>('Core_IsPluginInstalled');
 export const PySetUpdateNotificationStatus = callable<[{ status: boolean }], boolean>('updater.set_update_notifs_status');

--- a/src/include/head/library_updater.h
+++ b/src/include/head/library_updater.h
@@ -49,6 +49,7 @@ class Updater
 
     std::optional<json> GetCachedUpdates() const;
     bool HasCheckedForUpdates() const;
+    void ResetCheckState();
 
     std::optional<json> CheckForUpdates(bool force = false);
     std::string ResyncUpdates();


### PR DESCRIPTION
## Description

This PR fixes the issue where users are prompted to update a theme and restart Steam, but after restarting, they are prompted again for the same theme update.

## Root Cause

Two issues were identified:

1. **Silent git fetch failures**: The `git_remote_fetch` function in `UpdateTheme()` didn't check its return value, so if the fetch failed, the reset would use stale remote HEAD data.

2. **Cached update state**: After a theme update, the cached update check state wasn't being properly reset, which could cause stale data to persist.

## Changes

### Backend (C++):
- Added `ResetCheckState()` method to clear cached updates after a theme update
- Added error handling for `git_remote_fetch` to prevent silent failures

### Frontend (TypeScript):
- Added FFI function to expose reset functionality
- Theme update now resets the check state after successful update

## Testing

After this fix:
- Theme updates should properly clear the cache
- On next Steam restart, fresh update data will be fetched
- Git fetch failures are now properly detected

Fixes #649