### PR TITLE
Update PKGBUILD

### DIFF
--- a/packages/arch/PKGBUILD
+++ b/packages/arch/PKGBUILD
@@ -19,10 +19,12 @@ build() {
     cd             $srcdir/$_pkgdir
 
     echo -e        "\e[1m\e[92m==>\e[0m \e[1mBuilding Millennium...\e[0m"
-
+    
+    local node_bin="$srcdir/$_pkgdir/src/typescript/node_modules/.bin"
+    
     # CMake handles the TypeScript frontend build automatically via bun.
-    cmake -GNinja  . -DCMAKE_BUILD_TYPE=Release --preset linux-release -DDISTRO_ARCH=ON
-    cmake --build  build
+    PATH="$PATH:$node_bin" cmake -GNinja  . -DCMAKE_BUILD_TYPE=Release --preset linux-release -DDISTRO_ARCH=ON
+    PATH="$PATH:$node_bin" cmake --build  build
 }
 
 package() {


### PR DESCRIPTION
Issue: The build fails because millennium-ttc is not found during the TypeScript frontend compilation. This happens because the node_modules/.bin directory is not in the PATH when CMake/Bun is invoked.
Build log: https://pastebin.com/wVyP4Cx0

Fix: Prepend the local binary path to the PATH variable within the build() function
```bash
local node_bin="$srcdir/$_pkgdir/src/typescript/node_modules/.bin"
PATH="$PATH:$node_bin" cmake -GNinja  . -DCMAKE_BUILD_TYPE=Release --preset linux-release -DDISTRO_ARCH=ON
PATH="$PATH:$node_bin" cmake --build  build
````