### PR TITLE
fix: resolve Linux shutdown hang caused by reconnect loop

### DIFF
--- a/src/core/backend_mgr.cc
+++ b/src/core/backend_mgr.cc
@@ -210,6 +210,9 @@ done:
  */
 void BackendManager::Shutdown()
 {
+    if (m_hasShutdown) return;
+    m_hasShutdown = true;
+
     Logger.Warn("Unloading {} plugin(s) and preparing for exit...", this->m_pythonInstances.size() + this->m_luaThreadPool.size());
 
 #ifdef MILLENNIUM_32BIT

--- a/src/core/init.cc
+++ b/src/core/init.cc
@@ -274,17 +274,21 @@ void PluginLoader::StartFrontEnds()
 
     Logger.Warn("Unexpectedly Disconnected from Steam, attempting to reconnect...");
 
-#ifdef _WIN32
     auto start = std::chrono::steady_clock::now();
     while (std::chrono::steady_clock::now() - start < std::chrono::seconds(10)) {
+#ifdef _WIN32
         if (ab_shouldDisconnectFrontend.load()) {
             Logger.Log("Steam is shutting down, terminating frontend thread pool...");
+            return;
+        }
+#endif
+        if (g_shouldTerminateMillennium->flag.load()) {
+            Logger.Log("Millennium is shutting down, terminating frontend thread pool...");
             return;
         }
 
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
-#endif
 
     Logger.Warn("Reconnecting to Steam...");
 

--- a/src/include/millennium/backend_mgr.h
+++ b/src/include/millennium/backend_mgr.h
@@ -108,6 +108,7 @@ class BackendManager : public Singleton<BackendManager>
 
     static std::atomic<size_t>& Lua_GetPluginCounter(const std::string& plugin_name);
 
+    bool m_hasShutdown = false;
     std::mutex m_pythonMutex;
     std::vector<std::tuple<lua_State*, std::unique_ptr<std::mutex>>> m_luaMutexPool;
     PyThreadState* m_InterpreterThreadSave;

--- a/src/main.cc
+++ b/src/main.cc
@@ -186,12 +186,10 @@ void EntryMain()
     g_pluginLoader->StartBackEnds(manager);
     g_pluginLoader->StartFrontEnds(); /** IO blocking, returns once Steam dies */
 
-#ifdef _WIN32
     /** Shutdown backend service once frontend disconnects*/
     Logger.Log("Shutting down backend services...");
     (&manager)->Shutdown();
     Logger.Log("Backend services shut down successfully.");
-#endif
     Logger.Log("Finished shutting down frontend and backend...");
 
     {


### PR DESCRIPTION
On Linux, when Steam exits, the frontend WebSocket disconnects but StartFrontEnds() immediately recurses to reconnect — before StopMillennium() has a chance to set the termination flag. This creates a deadlock where the process never exits.

This change:
- Extends the 10-second reconnect wait (previously Windows-only) to all platforms, checking g_shouldTerminateMillennium during the window
- Calls BackendManager::Shutdown() from EntryMain() on all platforms, not just Windows, so plugin _unload() hooks are invoked reliably
- Adds a guard flag to prevent double-shutdown from the destructor


Please review - I do not know C that well so I leveraged Claude to implement this. I wasn't sure how the project felt about LLM-assisted changes, so if there's a more efficient way, or a reason why this wasn't supported up til now then please make changes or suggestions!

I just wanted to bring this to attention. Steam was not exiting due to _unload hooks not being called, allowing child processes created by plugins to reside in the background.