### PR TITLE
Fix grammar errors in sdk README

### DIFF
--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -2,9 +2,9 @@
 
 ## Introduction
 
-This library is used to develop plugins used for use with [Millennium](https://github.com/SteamClientHomebrew/Millennium).
+This library is used to develop plugins for use with [Millennium](https://github.com/SteamClientHomebrew/Millennium).
 
-This repository is a optimistic fork from [Decky Loader's](https://github.com/SteamDeckHomebrew/decky-loader) frontend library for developing plugins ([decky-frontend-lib](https://github.com/SteamDeckHomebrew/decky-frontend-lib)). Decky loader is a plugin loader for the Steam Deck similar to this project. Millennium's plugin loader portion was heavily inspired by decky, and it will hopefully serve to extend decky's existing library, and add functionality to portions of the Steam Client that weren't previously supported.
+This repository is an optimistic fork from [Decky Loader's](https://github.com/SteamDeckHomebrew/decky-loader) frontend library for developing plugins ([decky-frontend-lib](https://github.com/SteamDeckHomebrew/decky-frontend-lib)). Decky Loader is a plugin loader for the Steam Deck similar to this project. Millennium's plugin loader portion was heavily inspired by Decky, and it will hopefully serve to extend Decky's existing library and add functionality to portions of the Steam Client that weren't previously supported.
 
 With that being said, any issues you encounter while developing should be fowarded here, and not the Decky developers.
 
@@ -12,7 +12,7 @@ With that being said, any issues you encounter while developing should be foward
 
 This library is focused on usage by developers to provide custom React components based on those found in the Steam Client's React UI.  
 This method allows developers to add UI elements and code without clobbering the existing UI of the client in order to do so.  
-This library can also theoretically be used to extend existing UI elements of the Steam Client UI but this has not been tested extensively.
+This library can also theoretically be used to extend existing UI elements of the Steam Client UI, but this has not been tested extensively.
 
 ### Getting Started (Contributors)
 
@@ -22,4 +22,4 @@ This library can also theoretically be used to extend existing UI elements of th
 
 ### Getting Started (Developers)
 
-If you would like a feature added to library, please request it via a Github issue.
+If you would like a feature added to the library, please request it via a GitHub issue.


### PR DESCRIPTION
Noticed some grammar and capitalisation errors in the SDK README. Just made a small fix.