### PR TITLE
removing 'shallow=true' attributes from inputs url as it is irrelevant and breaking for lix

### DIFF
--- a/packages/nix/flake.nix
+++ b/packages/nix/flake.nix
@@ -4,22 +4,22 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
 
-    millennium-src.url = "github:SteamClientHomebrew/Millennium/defffd7b6f0cf4d5e53f5a892819966801475704?shallow=true";
+    millennium-src.url = "github:SteamClientHomebrew/Millennium/defffd7b6f0cf4d5e53f5a892819966801475704";
     millennium-src.flake = false;
 
-    zlib-src.url = "github:zlib-ng/zlib-ng/2.2.5?shallow=true";
-    luajit-src.url = "github:SteamClientHomebrew/LuaJIT/v2.1?shallow=true";
-    luajson-src.url = "github:SteamClientHomebrew/LuaJSON/0c1fabf07c42f3907287d1e4f729e0620c1fe6fd?shallow=true";
-    minhook-src.url = "github:TsudaKageyu/minhook/v1.3.4?shallow=true";
-    mini-src.url = "github:metayeti/mINI/0.9.18?shallow=true";
-    websocketpp-src.url = "github:zaphoyd/websocketpp/0.8.2?shallow=true";
-    fmt-src.url = "github:fmtlib/fmt/12.0.0?shallow=true";
-    json-src.url = "github:nlohmann/json/v3.12.0?shallow=true";
-    libgit2-src.url = "github:libgit2/libgit2/v1.9.1?shallow=true";
-    minizip-src.url = "github:zlib-ng/minizip-ng/4.0.10?shallow=true";
-    curl-src.url = "github:curl/curl/curl-8_13_0?shallow=true";
-    incbin-src.url = "github:graphitemaster/incbin/22061f51fe9f2f35f061f85c2b217b55dd75310d?shallow=true";
-    asio-src.url = "github:chriskohlhoff/asio/asio-1-30-0?shallow=true";
+    zlib-src.url = "github:zlib-ng/zlib-ng/2.2.5";
+    luajit-src.url = "github:SteamClientHomebrew/LuaJIT/v2.1";
+    luajson-src.url = "github:SteamClientHomebrew/LuaJSON/0c1fabf07c42f3907287d1e4f729e0620c1fe6fd";
+    minhook-src.url = "github:TsudaKageyu/minhook/v1.3.4";
+    mini-src.url = "github:metayeti/mINI/0.9.18";
+    websocketpp-src.url = "github:zaphoyd/websocketpp/0.8.2";
+    fmt-src.url = "github:fmtlib/fmt/12.0.0";
+    json-src.url = "github:nlohmann/json/v3.12.0";
+    libgit2-src.url = "github:libgit2/libgit2/v1.9.1";
+    minizip-src.url = "github:zlib-ng/minizip-ng/4.0.10";
+    curl-src.url = "github:curl/curl/curl-8_13_0";
+    incbin-src.url = "github:graphitemaster/incbin/22061f51fe9f2f35f061f85c2b217b55dd75310d";
+    asio-src.url = "github:chriskohlhoff/asio/asio-1-30-0";
 
     abseil-src.url = "github:abseil/abseil-cpp/20240722.0";
     re2-src.url = "github:google/re2/2025-11-05";


### PR DESCRIPTION
Several users have been having issues importing the nix configuration because of the `shallow=true` flag, because they use Lix in place of Nix.

I discussed this directly with some Lix/Nix developers and they stated that the `shallow` flag does not make sense here, as  github flakerefs are fetched as commit tarballs, and thus would not fetch the git tree.

This is why I'm proposing to get rid of the flag, as it is considered irrelevant from reputable sources.