### PR TITLE
edit deps in millennium.nix and millennium-32.nix

### DIFF
--- a/packages/nix/millennium-32.nix
+++ b/packages/nix/millennium-32.nix
@@ -69,11 +69,8 @@ pkgsi686Linux.stdenv.mkDerivation (finalAttrs: {
         deps = [
           "zlib"
           "luajit"
-          "minhook"
-          "mini"
           "websocketpp"
           "json"
-          "libgit2"
           "minizip"
           "curl"
           "asio"

--- a/packages/nix/millennium.nix
+++ b/packages/nix/millennium.nix
@@ -10,6 +10,10 @@
   millennium-frontend,
   millennium-32,
   millennium-64,
+  pkgsi686Linux,
+  cacert,
+  millennium-python ? pkgsi686Linux.python311,
+  ...
 }:
 stdenv.mkDerivation {
   pname = "millennium";


### PR DESCRIPTION
removes millennium-32.nix's minhook, mini, and libgit2 deps as no flake input is provided and they aren't necessary anymore

also adds pkgsi686Linux, cacert, and millennium-python to millennium.nix as they are referenced but not added as args