### PR TITLE
Edited dependencies in millennium(and 32).nix and migrated nix build script to bun

### DIFF
--- a/packages/nix/assets.nix
+++ b/packages/nix/assets.nix
@@ -15,7 +15,6 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/share/millennium/assets/
-    cp -r src/pipx $out/share/millennium/assets/pipx
 
     runHook postInstall
   '';

--- a/packages/nix/flake.lock
+++ b/packages/nix/flake.lock
@@ -105,17 +105,16 @@
     "millennium-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1777483535,
-        "narHash": "sha256-eqbNqc+5PibHLI8xgOrizXOVLcpE52MhmUR4o40S3PY=",
+        "lastModified": 1778645687,
+        "narHash": "sha256-PPdpCg/mv2+NwmYwzwIlMdrA8UD5VgG8glLrFb4/OcA=",
         "owner": "SteamClientHomebrew",
         "repo": "Millennium",
-        "rev": "defffd7b6f0cf4d5e53f5a892819966801475704",
+        "rev": "0e209621f181b5b26a0940414c2830710efd37ff",
         "type": "github"
       },
       "original": {
         "owner": "SteamClientHomebrew",
         "repo": "Millennium",
-        "rev": "defffd7b6f0cf4d5e53f5a892819966801475704",
         "type": "github"
       }
     },
@@ -172,11 +171,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770115704,
-        "narHash": "sha256-KHFT9UWOF2yRPlAnSXQJh6uVcgNcWlFqqiAZ7OVlHNc=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e6eae2ee2110f3d31110d5c222cd395303343b08",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {
@@ -217,8 +216,25 @@
         "minizip-src": "minizip-src",
         "nixpkgs": "nixpkgs",
         "re2-src": "re2-src",
+        "snare-src": "snare-src",
         "websocketpp-src": "websocketpp-src",
         "zlib-src": "zlib-src"
+      }
+    },
+    "snare-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774885337,
+        "narHash": "sha256-apxu7UrrLO5ymCXEIH11kcHW8barCk3W/+zZaEwzCTw=",
+        "owner": "shdwmtr",
+        "repo": "libsnare.h",
+        "rev": "d356aca3742d5b05c00efe4c43cc990e12ab794c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shdwmtr",
+        "repo": "libsnare.h",
+        "type": "github"
       }
     },
     "websocketpp-src": {

--- a/packages/nix/flake.lock
+++ b/packages/nix/flake.lock
@@ -68,23 +68,6 @@
         "type": "github"
       }
     },
-    "libgit2-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1749227175,
-        "narHash": "sha256-/xI3v7LNhpgfjv/m+sZwYDhhYvS6kQYxiiiG3+EF8Mw=",
-        "owner": "libgit2",
-        "repo": "libgit2",
-        "rev": "0060d9cf5666f015b1067129bd874c6cc4c9c7ac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "libgit2",
-        "ref": "v1.9.1",
-        "repo": "libgit2",
-        "type": "github"
-      }
-    },
     "luajit-src": {
       "flake": false,
       "locked": {
@@ -115,40 +98,6 @@
       "original": {
         "owner": "SteamClientHomebrew",
         "repo": "Millennium",
-        "type": "github"
-      }
-    },
-    "minhook-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1743163800,
-        "narHash": "sha256-0eGFfg365bb4zic1WTHMvKHbxuhhGp72/clu8OklHXs=",
-        "owner": "TsudaKageyu",
-        "repo": "minhook",
-        "rev": "c3fcafdc10146beb5919319d0683e44e3c30d537",
-        "type": "github"
-      },
-      "original": {
-        "owner": "TsudaKageyu",
-        "ref": "v1.3.4",
-        "repo": "minhook",
-        "type": "github"
-      }
-    },
-    "mini-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1743356736,
-        "narHash": "sha256-zBFFOlECbie7+62fTGf+NP4gNmfv2Qddw3ys6xn7o9U=",
-        "owner": "metayeti",
-        "repo": "mINI",
-        "rev": "52b66e987cb56171dc91d96115cdf094b6e4d7a0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "metayeti",
-        "ref": "0.9.18",
-        "repo": "mINI",
         "type": "github"
       }
     },
@@ -208,11 +157,8 @@
         "asio-src": "asio-src",
         "curl-src": "curl-src",
         "json-src": "json-src",
-        "libgit2-src": "libgit2-src",
         "luajit-src": "luajit-src",
         "millennium-src": "millennium-src",
-        "minhook-src": "minhook-src",
-        "mini-src": "mini-src",
         "minizip-src": "minizip-src",
         "nixpkgs": "nixpkgs",
         "re2-src": "re2-src",

--- a/packages/nix/flake.nix
+++ b/packages/nix/flake.nix
@@ -14,9 +14,6 @@
     minizip-src.url = "github:zlib-ng/minizip-ng/4.0.10";
     curl-src.url = "github:curl/curl/curl-8_13_0";
     asio-src.url = "github:chriskohlhoff/asio/asio-1-30-0";
-    minhook-src.url = "github:TsudaKageyu/minhook/v1.3.4";
-    mini-src.url = "github:metayeti/mINI/0.9.18";
-    libgit2-src.url = "github:libgit2/libgit2/v1.9.1";
     abseil-src.url = "github:abseil/abseil-cpp/20240722.0";
     re2-src.url = "github:google/re2/2025-11-05";
     snare-src.url = "github:shdwmtr/libsnare.h";
@@ -28,9 +25,6 @@
     minizip-src.flake = false;
     curl-src.flake = false;
     asio-src.flake = false;
-    minhook-src.flake = false;
-    mini-src.flake = false;
-    libgit2-src.flake = false;
     abseil-src.flake = false;
     re2-src.flake = false;
     snare-src.flake = false;

--- a/packages/nix/flake.nix
+++ b/packages/nix/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
 
-    millennium-src.url = "github:SteamClientHomebrew/Millennium/1bc62c94a06f25f7e8d7e269f11cd968cf576bff";
+    millennium-src.url = "github:SteamClientHomebrew/Millennium";
     millennium-src.flake = false;
 
     zlib-src.url = "github:zlib-ng/zlib-ng/2.2.5";
@@ -14,9 +14,12 @@
     minizip-src.url = "github:zlib-ng/minizip-ng/4.0.10";
     curl-src.url = "github:curl/curl/curl-8_13_0";
     asio-src.url = "github:chriskohlhoff/asio/asio-1-30-0";
-
+    minhook-src.url = "github:TsudaKageyu/minhook/v1.3.4";
+    mini-src.url = "github:metayeti/mINI/0.9.18";
+    libgit2-src.url = "github:libgit2/libgit2/v1.9.1";
     abseil-src.url = "github:abseil/abseil-cpp/20240722.0";
     re2-src.url = "github:google/re2/2025-11-05";
+    snare-src.url = "github:shdwmtr/libsnare.h";
 
     zlib-src.flake = false;
     luajit-src.flake = false;
@@ -25,9 +28,12 @@
     minizip-src.flake = false;
     curl-src.flake = false;
     asio-src.flake = false;
-
+    minhook-src.flake = false;
+    mini-src.flake = false;
+    libgit2-src.flake = false;
     abseil-src.flake = false;
     re2-src.flake = false;
+    snare-src.flake = false;
   };
 
   outputs =

--- a/packages/nix/frontend.nix
+++ b/packages/nix/frontend.nix
@@ -1,8 +1,7 @@
 {
-  nodejs_20,
-  pnpm_9,
-  fetchPnpmDeps,
-  pnpmConfigHook,
+  bun,
+  cacert,
+  nodejs,
 
   lib,
   stdenv,
@@ -10,32 +9,59 @@
   millennium-src,
   ...
 }:
-stdenv.mkDerivation (finalAttrs: {
+let
+  bunDeps = stdenv.mkDerivation {
+    pname = "millennium-frontend-bun-deps";
+    version = "2.36.0";
+
+    src = millennium-src;
+
+    nativeBuildInputs = [ bun cacert ];
+
+    buildPhase = ''
+      export HOME=$TMPDIR
+      bun install --cwd src/typescript --frozen-lockfile
+    '';
+
+    installPhase = ''
+      cp -rL --no-preserve=mode $HOME/.bun/. $out
+    '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-oZ8hDrJJ+0lwsMK2wz1C6RRSgNckJ+XQ33Am8/hTmMg=";
+  };
+in
+stdenv.mkDerivation {
   pname = "millennium-frontend";
   version = "2.36.0";
 
   src = millennium-src;
 
-  nativeBuildInputs = [
-    nodejs_20
-    pnpm_9
-    pnpmConfigHook
-  ];
-
-  pnpmRoot = "src/typescript/frontend";
-
-  pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs) version pname;
-    pnpm = pnpm_9;
-    src = "${finalAttrs.src}/src/typescript/frontend";
-    fetcherVersion = 3;
-    hash = "sha256-i53ZZ8ehOi3ybuckUo1Js5tC4LB0QCe4IQCwDwoegXg=";
-  };
+  nativeBuildInputs = [ bun nodejs ];
 
   buildPhase = ''
     runHook preBuild
 
-    pnpm --dir src/typescript/frontend run prod
+    export HOME=$(mktemp -d)
+    cp -r ${bunDeps} $HOME/.bun
+    chmod -R u+w $HOME/.bun
+    bun install --cwd src/typescript --frozen-lockfile
+    patchShebangs src/typescript
+
+    # Disable bun auto-install to prevent network access in later build steps
+    cat >> src/typescript/bunfig.toml <<'EOF'
+[install]
+auto = "disable"
+EOF
+
+    export PATH="$PWD/src/typescript/node_modules/.bin:$PATH"
+    tsc_js=$(find "$PWD/src/typescript/node_modules/.bun" -name "tsc.js" -path "*/typescript/lib/tsc.js" | head -1)
+    rollup_bin=$(find "$PWD/src/typescript/node_modules/.bun" -name "rollup" -path "*/rollup/dist/bin/rollup" | head -1)
+    (cd src/typescript/sdk/packages/client && node "$tsc_js" -b)
+    (cd src/typescript/sdk/packages/browser && node "$tsc_js" -b)
+    (cd src/typescript/ttc && node "$rollup_bin" -c)
+    (cd src/typescript/frontend && bun run prod)
 
     runHook postBuild
   '';
@@ -62,4 +88,4 @@ stdenv.mkDerivation (finalAttrs: {
       "x86_64-linux"
     ];
   };
-})
+}

--- a/packages/nix/frontend.nix
+++ b/packages/nix/frontend.nix
@@ -29,7 +29,7 @@ let
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-++emopf6oFSA0oLsp1i8SjQRzUtuYnrZ2QsFEaeu1k0=";
+    outputHash = "sha256-6XGna4P/4jXprK3MUjhqWRtO5MHsiA1KLSSn4Wk6bh8=";
   };
 in
 stdenv.mkDerivation {

--- a/packages/nix/frontend.nix
+++ b/packages/nix/frontend.nix
@@ -29,7 +29,7 @@ let
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-oZ8hDrJJ+0lwsMK2wz1C6RRSgNckJ+XQ33Am8/hTmMg=";
+    outputHash = "sha256-++emopf6oFSA0oLsp1i8SjQRzUtuYnrZ2QsFEaeu1k0=";
   };
 in
 stdenv.mkDerivation {

--- a/packages/nix/millennium-32.nix
+++ b/packages/nix/millennium-32.nix
@@ -44,12 +44,15 @@ pkgsi686Linux.stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DGITHUB_ACTION_BUILD=ON"
     "-DDISTRO_NIX=ON"
+    "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
+    "-DMILLENNIUM_BUILD_TESTS=OFF"
     "-DNIX_FRONTEND=${millennium-frontend}/share/frontend"
     "-DNIX_SHIMS=${millennium-shims}/share/millennium/shims"
     "-DNIX_PYTHON=${millennium-python}"
     "-DNIX_PYTHON_LIB=${millennium-python}/lib/libpython${millennium-python.pythonVersion}.so"
     "-DCURL_CA_BUNDLE=${cacert}/etc/ssl/certs/ca-bundle.crt"
     "-DCURL_CA_PATH=${cacert}/etc/ssl/certs"
+    "-DFETCHCONTENT_SOURCE_DIR_SNARE=${inputs.snare-src}"
   ];
 
   postPatch = ''
@@ -77,6 +80,7 @@ pkgsi686Linux.stdenv.mkDerivation (finalAttrs: {
           "minizip"
           "curl"
           "asio"
+          "re2"
         ];
       in
       lib.concatStrings (map (dep: "prepare_dep ${dep} \"${inputs."${dep}-src"}\"\n") deps)
@@ -104,8 +108,22 @@ pkgsi686Linux.stdenv.mkDerivation (finalAttrs: {
     echo "[Nix] Patching root CMakeLists to IGNORE 64-bit source..."
     sed -i '/add_subdirectory.*src\/hhx64)/s/^/#/' CMakeLists.txt
 
+    echo "[Nix] Patching root CMakeLists to SKIP loopback (hhx64 is built in millennium-64)..."
+    sed -i '/add_subdirectory.*loopback)/s/^/#/' CMakeLists.txt
+
     echo "[Nix] Patching src/CMakeLists.txt to replace dynamic target reference..."
     sed -i 's|\$<TARGET_FILE:hhx64>|libmillennium_hhx64.so|g' src/CMakeLists.txt
+
+    echo "[Nix] Fixing accidental UPDATER_DEBUG_MODE define left in source..."
+    sed -i 's|^#define UPDATER_DEBUG_MODE|// #define UPDATER_DEBUG_MODE|' src/engine/millennium_updater.cc
+
+    echo "[Nix] Suppressing -Werror for #embed C++26 extension (GCC supports it in C++23 mode)..."
+    sed -i 's/-Wpedantic -Werror/-Wpedantic -Werror -Wno-error=c++26-extensions/' src/CMakeLists.txt
+
+    echo "[Nix] Removing 64-bit-only targets (bootstrap64, pvs64) from bootstrap linux CMakeLists..."
+    awk '/^project\(bootstrap64/{found=1} !found{print}' \
+      src/bootstrap/linux/CMakeLists.txt > /tmp/bootstrap_linux.cmake
+    mv /tmp/bootstrap_linux.cmake src/bootstrap/linux/CMakeLists.txt
   '';
 
   buildPhase = ''
@@ -118,9 +136,10 @@ pkgsi686Linux.stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/lib/
-    install -Dm755 src/libmillennium_x86.so                      $out/lib/libmillennium_x86.so
-    install -Dm755 src/boot/linux/libmillennium_bootstrap_x86.so $out/lib/libmillennium_bootstrap_x86.so
-    install -Dm755 libmillennium_pvs64                           $out/lib/libmillennium_pvs64
+    x86so=$(find . -name "libmillennium_x86.so" | head -1)
+    boot86so=$(find . -name "libmillennium_bootstrap_x86.so" | head -1)
+    install -Dm755 "$x86so"    $out/lib/libmillennium_x86.so
+    install -Dm755 "$boot86so" $out/lib/libmillennium_bootstrap_x86.so
 
     runHook postInstall
   '';

--- a/packages/nix/millennium-32.nix
+++ b/packages/nix/millennium-32.nix
@@ -72,11 +72,8 @@ pkgsi686Linux.stdenv.mkDerivation (finalAttrs: {
         deps = [
           "zlib"
           "luajit"
-          "minhook"
-          "mini"
           "websocketpp"
           "json"
-          "libgit2"
           "minizip"
           "curl"
           "asio"

--- a/packages/nix/millennium-64.nix
+++ b/packages/nix/millennium-64.nix
@@ -4,6 +4,7 @@
   pkg-config,
   git,
   cacert,
+  python3,
 
   lib,
   stdenv,
@@ -25,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     git
+    python3
   ];
 
   buildInputs = [
@@ -39,6 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-DGITHUB_ACTION_BUILD=ON"
     "-DDISTRO_NIX=ON"
     "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
+    "-DMILLENNIUM_BUILD_TESTS=OFF"
+    "-DFETCHCONTENT_SOURCE_DIR_SNARE=${inputs.snare-src}"
   ];
 
   postPatch = ''
@@ -73,11 +77,38 @@ stdenv.mkDerivation (finalAttrs: {
 
     echo "[Nix] Patching CMakeLists to IGNORE 32-bit source..."
     sed -i '/add_subdirectory.*src)/s/^/#/' CMakeLists.txt
+
+    echo "[Nix] Writing cmake fragment for abseil + re2 (normally from bootstrap_deps.cmake via src/)..."
+    # Patch re2 to skip install(EXPORT) which fails because absl targets aren't installed
+    python3 - deps/re2/CMakeLists.txt <<'PEOF'
+import sys, re
+with open(sys.argv[1]) as f:
+    content = f.read()
+content = re.sub(r'install\(EXPORT.*?\)', "", content, flags=re.DOTALL)
+with open(sys.argv[1], 'w') as f:
+    f.write(content)
+PEOF
+
+    cat > nix_64bit_deps.cmake <<'NIXEOF'
+set(ABSL_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+set(RE2_BUILD_TESTING  OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(absl SOURCE_DIR "''${MILLENNIUM_BASE}/deps/abseil" OVERRIDE_FIND_PACKAGE)
+FetchContent_MakeAvailable(absl)
+FetchContent_Declare(re2 SOURCE_DIR "''${MILLENNIUM_BASE}/deps/re2" SOURCE_SUBDIR fakedir)
+FetchContent_MakeAvailable(re2)
+NIXEOF
+    sed -i '/FetchContent_MakeAvailable(snare)/a include(''${CMAKE_SOURCE_DIR}/nix_64bit_deps.cmake)' CMakeLists.txt
   '';
 
   buildPhase = ''
     runHook preBuild
     cmake --build .
+
+    # pvs64 is a pure-stdlib 64-bit helper; compile it here since the 32-bit build cannot emit -m64
+    g++ -m64 -std=c++17 -O2 -Wall -Wextra \
+      ../src/bootstrap/linux/millennium_pvs64.cc \
+      -o libmillennium_pvs64
+
     runHook postBuild
   '';
 
@@ -85,7 +116,9 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/lib/
-    install -Dm755 src/hhx64/libmillennium_hhx64.so $out/lib/libmillennium_hhx64.so
+    so=$(find . -name "libmillennium_hhx64.so" | head -1)
+    install -Dm755 "$so" $out/lib/libmillennium_hhx64.so
+    install -Dm755 libmillennium_pvs64 $out/lib/libmillennium_pvs64
 
     runHook postInstall
   '';

--- a/packages/nix/millennium.nix
+++ b/packages/nix/millennium.nix
@@ -1,8 +1,7 @@
 {
   lib,
+  pkgs,
   stdenv,
-  callPackage,
-  fetchFromGitHub,
 
   inputs,
   millennium-shims,
@@ -10,6 +9,7 @@
   millennium-frontend,
   millennium-32,
   millennium-64,
+  millennium-python ? pkgs.pkgsi686Linux.python311,
 }:
 stdenv.mkDerivation {
   pname = "millennium";
@@ -21,11 +21,11 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    pkgsi686Linux.gtk3
-    pkgsi686Linux.libpsl
-    pkgsi686Linux.openssl
-    pkgsi686Linux.libxtst
-    cacert
+    pkgs.pkgsi686Linux.gtk3
+    pkgs.pkgsi686Linux.libpsl
+    pkgs.pkgsi686Linux.openssl
+    pkgs.pkgsi686Linux.libxtst
+    pkgs.cacert
     millennium-python
   ];
 
@@ -39,8 +39,8 @@ stdenv.mkDerivation {
     "-DNIX_FRONTEND=${millennium-frontend}/share/frontend"
     "-DNIX_SHIMS=${millennium-shims}/share/millennium/shims"
     "-DNIX_PYTHON=${millennium-python}"
-    "-DCURL_CA_BUNDLE=${cacert}/etc/ssl/certs/ca-bundle.crt"
-    "-DCURL_CA_PATH=${cacert}/etc/ssl/certs"
+    "-DCURL_CA_BUNDLE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+    "-DCURL_CA_PATH=${pkgs.cacert}/etc/ssl/certs"
     "--preset=linux-release"
   ];
 
@@ -100,6 +100,9 @@ stdenv.mkDerivation {
 
     echo "[Nix Millennium] Merging 64-bit libraries..."
     cp -v ${millennium-64}/lib/*.so $out/lib/
+
+    echo "[Nix Millennium] Copying pvs64 helper..."
+    cp -v ${millennium-64}/lib/libmillennium_pvs64 $out/lib/
   '';
 
   passthru = {

--- a/packages/nix/shims.nix
+++ b/packages/nix/shims.nix
@@ -29,7 +29,7 @@ let
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-ErSfKormY1L+f8rSvJwn1cozsDC+SlWCb7IHGIC82pk=";
+    outputHash = "sha256-th5buRdmgV3R39iGuOYVpHZZ70hVT+BlDr5rNE1Vl1M=";
   };
 in
 stdenv.mkDerivation {

--- a/packages/nix/shims.nix
+++ b/packages/nix/shims.nix
@@ -1,8 +1,7 @@
 {
-  nodejs_20,
-  pnpm_9,
-  fetchPnpmDeps,
-  pnpmConfigHook,
+  bun,
+  cacert,
+  nodejs,
 
   lib,
   stdenv,
@@ -10,32 +9,57 @@
   millennium-src,
   ...
 }:
-stdenv.mkDerivation (finalAttrs: {
+let
+  bunDeps = stdenv.mkDerivation {
+    pname = "millennium-shims-bun-deps";
+    version = "2.36.0";
+
+    src = millennium-src;
+
+    nativeBuildInputs = [ bun cacert ];
+
+    buildPhase = ''
+      export HOME=$TMPDIR
+      bun install --cwd src/typescript --frozen-lockfile
+    '';
+
+    installPhase = ''
+      cp -rL --no-preserve=mode $HOME/.bun/. $out
+    '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-ErSfKormY1L+f8rSvJwn1cozsDC+SlWCb7IHGIC82pk=";
+  };
+in
+stdenv.mkDerivation {
   pname = "millennium-shims";
   version = "2.36.0";
 
   src = millennium-src;
 
-  nativeBuildInputs = [
-    nodejs_20
-    pnpm_9
-    pnpmConfigHook
-  ];
-
-  pnpmRoot = "src/typescript";
-
-  pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs) version pname;
-    pnpm = pnpm_9;
-    src = "${finalAttrs.src}/src/typescript";
-    fetcherVersion = 3;
-    hash = "sha256-H7k+nkNCb4yuaXcZVmfMI0sqgdYgTO3C2MlXPpYX0x0=";
-  };
+  nativeBuildInputs = [ bun nodejs ];
 
   buildPhase = ''
     runHook preBuild
 
-    pnpm --dir src/typescript run build
+    export HOME=$(mktemp -d)
+    cp -r ${bunDeps} $HOME/.bun
+    chmod -R u+w $HOME/.bun
+    bun install --cwd src/typescript --frozen-lockfile
+    patchShebangs src/typescript
+
+    # Disable bun auto-install to prevent network access in later build steps
+    cat >> src/typescript/bunfig.toml <<'EOF'
+[install]
+auto = "disable"
+EOF
+
+    tsc_js=$(find "$PWD/src/typescript/node_modules/.bun" -name "tsc.js" -path "*/typescript/lib/tsc.js" | head -1)
+    rollup_bin=$(find "$PWD/src/typescript/node_modules/.bun" -name "rollup" -path "*/rollup/dist/bin/rollup" | head -1)
+    (cd src/typescript/sdk/packages/client && node "$tsc_js" -b)
+    (cd src/typescript/sdk/packages/cdp-isolated-ctx && node "$rollup_bin" -c)
+    (cd src/typescript/sdk/packages/loader && node "$rollup_bin" -c)
 
     runHook postBuild
   '';
@@ -44,7 +68,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/share/millennium/shims
-    cp -r src/sdk/packages/loader/build/* $out/share/millennium/shims/
+    cp -r src/typescript/sdk/packages/loader/build/* $out/share/millennium/shims/
+    cp src/typescript/sdk/packages/cdp-isolated-ctx/build/cdp-isolated-ctx.js $out/share/millennium/shims/
 
     runHook postInstall
   '';
@@ -62,4 +87,4 @@ stdenv.mkDerivation (finalAttrs: {
       "x86_64-linux"
     ];
   };
-})
+}


### PR DESCRIPTION
Fixed `pkgsi686Linux` and `cacert` unresolved variable issues in the nix files by referencing `pkgs`. Since the main repository moved to bun over pnpm, the nix build now creates a bun-built frontend.

Noteworthy changes/caveats
1.  removed all references to `pnpm`
2. the `sed` in millennium-32.nix is patching over an upstream bug (`#define UPDATER_DEBUG_MODE` left in a release build path)
3. `-Wno-error=c++26-extensions` patch, since GCC allows `#embed` as an extension in `C++23` mode but `-Wpedantic -Werror` rejects it
4. `pvs64` is now compiled in millennium-64 rather than the 32-bit build, since `pkgsi686Linux.stdenv` cannot emit 64-bit code.
5. `cdp-isolated-ctx` was missing from the shims build and has been added
6. assets.nix used to refer to `src/pipx` which was removed in `bf091385`
7. Since nixpkgs bumped the version of bun from 1.3.8 to 1.3.13, flake.lock was updated. The bun FOD hashes in frontend.nix and shims.nix were recomputed accordingly.
8. minhook, mini, libgit2 inputs removed from flake.nix as they are no longer referenced in the source.

The build successfully compiled and the resulting steam client worked visually.