### PR TITLE
fix: OpenSSL 3.5/GCC 16 compatibility + Bootstrap arch fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,11 @@ jobs:
             - name: Build Millennium Backend
               shell: pwsh
               run: |
-                  pushd "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools"
+                  $vsInstallPath = & "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" `
+                    -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+                    -property installationPath
+                  $vsToolsPath = Join-Path $vsInstallPath "Common7\Tools"
+                  pushd $vsToolsPath
 
                   # Initialize Visual Studio x64 host/toolchain and import the environment into PowerShell
                   cmd /c "VsDevCmd.bat -arch=x64 -host_arch=x64 & set" |
@@ -173,7 +177,7 @@ jobs:
                   }
 
                   popd
-                  Write-Host "`nVisual Studio 2022 x64 Command Prompt variables set." -ForegroundColor Yellow
+                  Write-Host "`nVisual Studio x64 Command Prompt variables set (from: $vsInstallPath)" -ForegroundColor Yellow
 
                   # optional sanity checks (helpful for CI debugging)
                   cmd /c "where cl.exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
             - name: Download Semantic Release
               run: |
-                  npm install -g pnpm
+                  npm install -g pnpm@9
                   pnpm install --save-dev semantic-release @semantic-release/github @semantic-release/exec @semantic-release/changelog @semantic-release/git
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -156,7 +156,7 @@ jobs:
                   node-version: 24
 
             - name: Setup PNPM
-              run: npm install -g pnpm
+              run: npm install -g pnpm@9
 
             - name: Build Millennium Backend
               shell: pwsh
@@ -259,7 +259,7 @@ jobs:
 
             - name: Download Python Dependencies
               run: |
-                  npm install -g pnpm
+                  npm install -g pnpm@9
 
                   wget https://github.com/shdwmtr/pybuilder/releases/download/v1.0.6/python-3.11.8-32-bit.tar.gz -O python-3.11.8-32-bit.tar.gz
                   mkdir -p ~/build/opt/python-i686-3.11.8

--- a/scripts/.releaserc
+++ b/scripts/.releaserc
@@ -1,7 +1,7 @@
 {
   "branches": [
     "main",
-    "legacy",
+    { "name": "legacy", "channel": false },
     {
       "name": "next",
       "prerelease": "beta"

--- a/scripts/.releaserc
+++ b/scripts/.releaserc
@@ -1,6 +1,7 @@
 {
   "branches": [
     "main",
+    "legacy",
     {
       "name": "next",
       "prerelease": "beta"

--- a/scripts/.releaserc
+++ b/scripts/.releaserc
@@ -1,7 +1,7 @@
 {
   "branches": [
     "main",
-    { "name": "legacy", "channel": false },
+    { "name": "legacy", "channel": false, "prerelease": false },
     {
       "name": "next",
       "prerelease": "beta"

--- a/scripts/version
+++ b/scripts/version
@@ -1,2 +1,2 @@
 # current version of millennium
-v2.36.3
+v2.36.4

--- a/scripts/version
+++ b/scripts/version
@@ -1,2 +1,2 @@
 # current version of millennium
-v2.36.1
+v2.36.2

--- a/scripts/version
+++ b/scripts/version
@@ -1,2 +1,2 @@
 # current version of millennium
-v2.36.2
+v2.36.3

--- a/src/boot/linux/CMakeLists.txt
+++ b/src/boot/linux/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
-project(unix-hooks LANGUAGES CXX)
+project(unix-hooks LANGUAGES C CXX)
 set(CMAKE_C_STANDARD 11)
 
 add_library(unix-hooks SHARED main.c)
+
+target_compile_options(unix-hooks PRIVATE -m32)
+target_link_options(unix-hooks PRIVATE -m32)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_definitions(unix-hooks PRIVATE MILLENNIUM_RUNTIME_PATH="$<TARGET_FILE:Millennium>")

--- a/src/frontend/pnpm-workspace.yaml
+++ b/src/frontend/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+    - '@parcel/watcher'

--- a/src/frontend/pnpm-workspace.yaml
+++ b/src/frontend/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-onlyBuiltDependencies:
-    - '@parcel/watcher'

--- a/src/sdk/package.json
+++ b/src/sdk/package.json
@@ -40,5 +40,8 @@
       "electron",
       "nx"
     ]
-  }
+  },
+  "workspaces": [
+    "packages/*"
+  ]
 }

--- a/src/sdk/packages/client/src/components/Field.ts
+++ b/src/sdk/packages/client/src/components/Field.ts
@@ -4,25 +4,26 @@ import { Export, findModuleExport } from '../webpack';
 import { FooterLegendProps } from './FooterLegend';
 
 export interface FieldProps extends FooterLegendProps {
-	children?: ReactNode;
-	label?: ReactNode;
-	bottomSeparator?: 'standard' | 'thick' | 'none';
-	description?: ReactNode;
-	disabled?: boolean;
-	icon?: ReactNode;
-	inlineWrap?: 'keep-inline' | 'shift-children-below'; // If label is too long it will move shildren below before starting to wrap label
-	childrenLayout?: 'below' | 'inline';
-	childrenContainerWidth?: 'min' | 'max' | 'fixed'; // Does not work with childrenLayout==='below'
-	spacingBetweenLabelAndChild?: 'none'; // This applies only when childrenLayout==='below'
-	padding?: 'none' | 'standard' | 'compact';
-	className?: string;
-	highlightOnFocus?: boolean;
-	indentLevel?: number;
-	verticalAlignment?: 'center' | 'none'; // Alligns inline label with children
-	focusable?: boolean; // Allows to get focus without any focusable children or on* callbacks
-	onActivate?: (e: CustomEvent | MouseEvent) => void;
-	onClick?: (e: CustomEvent | MouseEvent) => void;
+    children?: ReactNode;
+    label?: ReactNode;
+    bottomSeparator?: 'standard' | 'thick' | 'none';
+    description?: ReactNode;
+    disabled?: boolean;
+    icon?: ReactNode;
+    inlineWrap?: 'keep-inline' | 'shift-children-below'; // If label is too long it will move shildren below before starting to wrap label
+    childrenLayout?: 'below' | 'inline';
+    childrenContainerWidth?: 'min' | 'max' | 'fixed'; // Does not work with childrenLayout==='below'
+    spacingBetweenLabelAndChild?: 'none'; // This applies only when childrenLayout==='below'
+    padding?: 'none' | 'standard' | 'compact';
+    className?: string;
+    highlightOnFocus?: boolean;
+    indentLevel?: number;
+    verticalAlignment?: 'center' | 'none'; // Alligns inline label with children
+    focusable?: boolean; // Allows to get focus without any focusable children or on* callbacks
+    onActivate?: (e: CustomEvent | MouseEvent) => void;
+    onClick?: (e: CustomEvent | MouseEvent) => void;
 }
 
 /** @component React Components */
-export const Field = findModuleExport((e: Export) => e?.render?.toString().includes('"shift-children-below"')) as FC<FieldProps & RefAttributes<HTMLDivElement>>;
+export const Field = findModuleExport((e: Export) => (e?.toString()?.includes('().Field') && e?.toString()?.includes('"shift-children-below"'))
+    || e?.render?.toString()?.includes('"shift-children-below"')) as FC<FieldProps & RefAttributes<HTMLDivElement>>;

--- a/src/sdk/packages/client/src/components/Item.ts
+++ b/src/sdk/packages/client/src/components/Item.ts
@@ -1,13 +1,14 @@
 import { ReactNode } from 'react';
 
 export interface ItemProps {
-  label?: ReactNode;
-  description?: ReactNode;
-  children?: ReactNode;
-  layout?: 'below' | 'inline';
-  icon?: ReactNode;
-  bottomSeparator?: 'standard' | 'thick' | 'none';
-  indentLevel?: number;
-  tooltip?: string;
-  highlightOnFocus?: boolean;
+    label?: ReactNode;
+    description?: ReactNode;
+    children?: ReactNode;
+    layout?: 'below' | 'inline';
+    icon?: ReactNode;
+    bottomSeparator?: 'standard' | 'thick' | 'none';
+    childrenContainerWidth?: 'min' | 'max' | 'fixed'; // Does not work with layout==='below'
+    indentLevel?: number;
+    tooltip?: string;
+    highlightOnFocus?: boolean;
 }

--- a/src/sdk/pnpm-workspace.yaml
+++ b/src/sdk/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
     - 'packages/*'
+
+onlyBuiltDependencies:
+    - '@parcel/watcher'
+    - electron
+    - nx


### PR DESCRIPTION
## Fixes

### 1. Bootstrap `-m32` (src/boot/linux/CMakeLists.txt)
The bootstrap target uses a nested `project()` call which doesnt inherit `CMAKE_C_FLAGS` from the parent. Added explicit `-m32` via `target_compile_options` / `target_link_options`. Otherwise the 32-bit Steam process cannot load a 64-bit bootstrap `.so`.

### 2. pnpm workspaces (src/sdk/package.json)
Added `"workspaces": ["packages/*"]` so pnpm resolves linked packages (`@steambrew/client`, `@steambrew/webkit`) correctly.

### 3. LuaJIT CCallState fix (build/_deps/luajit-src/src/lj_ccall.h)
On GCC 16+ with `LJ_TARGET_X86`, the `CCallState` struct lacks `nfpr` member but `vm_x86.dasc` references it. Patch:
```c
#elif LJ_TARGET_X86
  uint8_t nfpr;          /* Number of arguments in FPRs. */
  uint8_t resx87;        /* Result on x87 stack: 1:float, 2:double. */
```

### 4. OpenSSL 3.5 ENGINE removal
OpenSSL 3.5 removed the ENGINE API. Build with `-DOPENSSL_NO_ENGINE` to avoid compile errors.

## Build tested on
- Fedora 44, GCC 16.1, kernel 6.x
- 32-bit main lib ✓, 64-bit hook helper ✓, 32-bit bootstrap ✓