### PR TITLE
feat(quick-access): expose window.MILLENNIUM_SIDEBAR for plugins

### DIFF
--- a/src/typescript/frontend/quick-access/index.tsx
+++ b/src/typescript/frontend/quick-access/index.tsx
@@ -28,7 +28,7 @@
  * SOFTWARE.
  */
 
-import { ErrorBoundary, getParentWindow } from '@steambrew/client';
+import { ErrorBoundary, getParentWindow, registerMillenniumSidebar } from '@steambrew/client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { TitleView } from '../components/QuickAccessTitle';
 import { PluginSelectorView, RenderPluginView } from './PluginView';
@@ -36,6 +36,7 @@ import { BrowserManagerHook } from './browserHook';
 import Styles, { MillenniumDesktopSidebarStyles } from '../utils/styles';
 import { DesktopSideBarFocusedItemType, useDesktopMenu } from './DesktopMenuContext';
 import { useQuickAccessStore } from './quickAccessStore';
+import { backend } from '../utils/ffi';
 import { RenderThemeView, ThemeSelectorView } from './ThemeView';
 import { Placeholder } from '../components/Placeholder';
 import { MillenniumIcons } from '../components/Icons';
@@ -74,6 +75,34 @@ export const MillenniumDesktopSidebar: React.FC = () => {
 			unsubscribeOpen();
 			unsubscribeClose();
 		};
+	}, []);
+
+	// Register this sidebar's controls with the SDK's MillenniumSidebar API, so
+	// plugins can drive it (open their own panel, another plugin's, or open/close
+	// the list) through @steambrew/client without touching Millennium internals.
+	useEffect(() => {
+		registerMillenniumSidebar({
+			openPlugin: async (pluginName: string): Promise<boolean> => {
+				try {
+					const plugins = await backend.plugins.getPlugins();
+					const plugin = plugins?.find((p: any) => p?.data?.name === pluginName);
+					const store = useQuickAccessStore.getState();
+					if (!plugin) {
+						store.openQuickAccess();
+						return false;
+					}
+					store.openQuickAccess({
+						data: { libraryItem: plugin, libraryItemType: DesktopSideBarFocusedItemType.PLUGIN },
+					});
+					return true;
+				} catch (error) {
+					console.error('[Millennium] MillenniumSidebar.openPlugin failed:', error);
+					return false;
+				}
+			},
+			open: () => useQuickAccessStore.getState().openQuickAccess(),
+			close: () => useQuickAccessStore.getState().closeQuickAccess(),
+		});
 	}, []);
 
 	const closeQuickAccess = useCallback(async () => {

--- a/src/typescript/sdk/packages/client/src/index.ts
+++ b/src/typescript/sdk/packages/client/src/index.ts
@@ -7,6 +7,7 @@ export * from './deck-hooks';
 export * from './globals';
 export * from './millennium-api';
 export * from './modules';
+export * from './millennium-sidebar';
 export * from './constSysfsExpr';
 export * from './utils';
 export * from './webpack';

--- a/src/typescript/sdk/packages/client/src/millennium-sidebar.ts
+++ b/src/typescript/sdk/packages/client/src/millennium-sidebar.ts
@@ -1,0 +1,47 @@
+/**
+ * Drive the Millennium desktop sidebar (the quick-access panel that hosts plugin
+ * settings) from a plugin - open its own panel, open another plugin's, or
+ * open/close the list - instead of waiting for the user to click "Configure" in
+ * the plugin manager.
+ *
+ * The implementation lives in Millennium's frontend, which owns the sidebar; it
+ * injects itself via `registerMillenniumSidebar` when the sidebar mounts. Plugins
+ * only ever call the public `MillenniumSidebar` methods.
+ */
+type MillenniumSidebarControls = {
+	openPlugin: (pluginName: string) => Promise<boolean>;
+	open: () => void;
+	close: () => void;
+};
+
+let impl: MillenniumSidebarControls | undefined;
+
+/**
+ * Register the sidebar controls.
+ *
+ * @internal Called by Millennium's frontend when the sidebar mounts.
+ */
+export function registerMillenniumSidebar(controls: MillenniumSidebarControls): void {
+	impl = controls;
+}
+
+export const MillenniumSidebar = {
+	/**
+	 * Open the sidebar focused on a plugin by its internal `name` (the same panel
+	 * the plugin manager's "Configure" opens). Resolves `false` if there is no
+	 * such plugin, or the sidebar is unavailable.
+	 */
+	openPlugin(pluginName: string): Promise<boolean> {
+		return impl?.openPlugin(pluginName) ?? Promise.resolve(false);
+	},
+
+	/** Open the sidebar on its home (the plugin/theme list). */
+	open(): void {
+		impl?.open();
+	},
+
+	/** Close the sidebar. */
+	close(): void {
+		impl?.close();
+	},
+};


### PR DESCRIPTION
### Summary

Adds `MillenniumSidebar` to `@steambrew/client` - a small, typed API that lets a
plugin drive the desktop sidebar (the quick-access panel that hosts plugin
settings):

- `MillenniumSidebar.openPlugin(name): Promise<boolean>` - open the sidebar
  focused on a plugin by its internal name (same as the plugin manager's
  "Configure"). Resolves `false` if no such plugin.
- `MillenniumSidebar.open(): void` - open the sidebar on its home (plugin/theme list).
- `MillenniumSidebar.close(): void` - close the sidebar.

The implementation lives in Millennium's frontend (it owns the sidebar store), so
the frontend registers it with the SDK when the sidebar mounts; plugins only call
the public methods. No global is exposed to plugins.

### Details

A plugin can render a panel in the sidebar, but nothing lets it *open* that panel
from its own code - only the user clicking "Configure" can. I'm building a plugin
that shows a toast and, when you click it, opens its panel in the sidebar; that
isn't possible today, and this PR makes it possible.

This is also groundwork for plugin interop / dependencies (asked for in issues).
With it a plugin can:

- open **its own** settings on an action - e.g. a notification's onClick, or a
  first-run "finish setup" prompt;
- open **another** plugin's settings - useful for compatibility / "this needs
  plugin X setting" flows;
- open or close the sidebar programmatically.

### Usage

```ts
import { MillenniumSidebar } from '@steambrew/client';

MillenniumSidebar.openPlugin('my-plugin');    // open my own panel
MillenniumSidebar.openPlugin('other-plugin'); // open another plugin's panel
MillenniumSidebar.open();                      // open the list
MillenniumSidebar.close();                     // close the sidebar
```
