### PR TITLE
Refactor WebKit URL validation to use libcurl

### DIFF
--- a/build_ninja.bat
+++ b/build_ninja.bat
@@ -1,0 +1,4 @@
+call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+set PATH=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja;%PATH%
+cmake -B build -G Ninja -DMILLENNIUM_BUILD_TO_STEAM_PATH=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF
+cmake --build build --config Release

--- a/build_ninja.bat
+++ b/build_ninja.bat
@@ -1,4 +1,0 @@
-call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-set PATH=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja;%PATH%
-cmake -B build -G Ninja -DMILLENNIUM_BUILD_TO_STEAM_PATH=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF
-cmake --build build --config Release

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SOURCE_FILES
     engine/star_parser.cc
     engine/plugin_webkit_store.cc
     engine/plugin_webkit_world_mgr.cc
+    engine/target_url.cc
     engine/thread_pool.cc
     util/cmdline_parser.cc
     util/file_watcher.cc

--- a/src/engine/http_hooks.cc
+++ b/src/engine/http_hooks.cc
@@ -39,28 +39,11 @@
 #include "millennium/virtfs.h"
 #include "millennium/types.h"
 #include "millennium/target_url.h"
-#include "millennium/http.h"
 
 #include <nlohmann/json_fwd.hpp>
 #include <thread>
 
 std::atomic<unsigned long long> g_hookedModuleId{ 0 };
-
-
-const std::vector<std::regex> g_js_and_css_hook_blacklist = {
-    /** Ignore paypal related content */
-    std::regex(R"(https?://(?:[\w-]+\.)*paypal\.com/[^\s"']*)"),
-    std::regex(R"(https?://(?:[\w-]+\.)*paypalobjects\.com/[^\s"']*)"),
-    std::regex(R"(https?://(?:[\w-]+\.)*recaptcha\.net/[^\s"']*)"),
-
-    /** Ignore youtube related content */
-    std::regex(R"(https?://(?:[\w-]+\.)*(?:youtube(?:-nocookie)?|youtu|ytimg|googlevideo|googleusercontent|studioyoutube)\.com/[^\s"']*)"),
-    std::regex(R"(https?://(?:[\w-]+\.)*youtu\.be/[^\s"']*)"),
-
-    /** Ignore Chrome Web Store (causes a webhelper crash on Fetch.fulfillRequest) */
-    std::regex(R"(https?://(?:[\w-]+\.)*chromewebstore\.google\.com/[^\s"']*)"),
-};
-// clang-format on
 
 json make_headers(const std::vector<std::pair<std::string, std::string>>& headers)
 {

--- a/src/engine/http_hooks.cc
+++ b/src/engine/http_hooks.cc
@@ -38,17 +38,14 @@
 #include "millennium/url_parser.h"
 #include "millennium/virtfs.h"
 #include "millennium/types.h"
+#include "millennium/target_url.h"
+#include "millennium/http.h"
 
 #include <nlohmann/json_fwd.hpp>
 #include <thread>
-#include <unordered_set>
 
 std::atomic<unsigned long long> g_hookedModuleId{ 0 };
 
-// clang-format off
-const std::vector<std::regex> g_js_hook_blacklist = {
-    std::regex(R"(https?://checkout\.steampowered\.com/[^\s"']*)"),
-};
 
 const std::vector<std::regex> g_js_and_css_hook_blacklist = {
     /** Ignore paypal related content */
@@ -252,11 +249,10 @@ void network_hook_ctl::mime_doc_request_handler(const nlohmann::basic_json<>& me
     const http_code statusCode = message["responseStatusCode"].get<http_code>();
 
     /** check if the request URL is a do-not-hook URL. */
-    for (const auto& pattern : g_js_and_css_hook_blacklist) {
-        if (std::regex_match(requestUrl, pattern)) {
-            m_cdp->send_host("Fetch.continueResponse", params);
-            return;
-        }
+    target_url target(requestUrl);
+    if (!target.is_safe_for_network_hooks()) {
+        m_cdp->send_host("Fetch.continueResponse", params);
+        return;
     }
 
     const auto redirect_codes = { http_code::SEE_OTHER, http_code::MOVED_PERMANENTLY, http_code::FOUND, http_code::TEMPORARY_REDIRECT, http_code::PERMANENT_REDIRECT };
@@ -268,7 +264,7 @@ void network_hook_ctl::mime_doc_request_handler(const nlohmann::basic_json<>& me
         }
     }
 
-    const processed_hooks hooks = apply_user_webkit_hooks(requestUrl);
+    const processed_hooks hooks = apply_user_webkit_hooks(target);
     if (hooks.empty()) {
         m_cdp->send_host("Fetch.continueResponse", params);
         return;
@@ -300,14 +296,20 @@ void network_hook_ctl::mime_doc_request_handler(const nlohmann::basic_json<>& me
     m_cdp->send_host("Fetch.fulfillRequest", fullfillParams);
 }
 
-network_hook_ctl::processed_hooks network_hook_ctl::apply_user_webkit_hooks(const std::string& requestUrl) const
+network_hook_ctl::processed_hooks network_hook_ctl::apply_user_webkit_hooks(const target_url& target) const
 {
     processed_hooks result;
     auto hookList = get_hook_list();
     bool anyHookMatched = false;
+    bool safe_for_js = target.is_safe_for_js();
 
     for (const auto& hook : hookList) {
-        if (!std::regex_match(requestUrl, hook.hook.url_pattern)) continue;
+        if (!std::regex_match(target.raw_url(), hook.hook.url_pattern)) continue;
+        
+        if (hook.hook.type == TagTypes::JAVASCRIPT && !safe_for_js) {
+            continue;
+        }
+
         anyHookMatched = true;
 
         if (hook.hook.type == TagTypes::STYLESHEET)

--- a/src/engine/plugin_webkit_world_mgr.cc
+++ b/src/engine/plugin_webkit_world_mgr.cc
@@ -36,6 +36,7 @@
 #include "millennium/logger.h"
 #include "millennium/auth.h"
 #include "millennium/url_parser.h"
+#include "millennium/target_url.h"
 #include <format>
 
 webkit_world_mgr::webkit_world_mgr(std::shared_ptr<cdp_client> client, std::shared_ptr<plugin_manager> plugin_manager, std::shared_ptr<network_hook_ctl> network_hook_ctl,
@@ -73,58 +74,10 @@ void webkit_world_mgr::initialize()
     }
 }
 
-static bool is_steam_owned_url(const std::string& url)
-{
-    /* extract just the hostname: skip scheme, stop at port / path / query */
-    auto scheme_end = url.find("://");
-    if (scheme_end == std::string::npos) return false;
-    auto host_start = scheme_end + 3;
-    auto host_end = url.find_first_of(":/?#", host_start);
-    std::string host = url.substr(host_start, host_end == std::string::npos ? std::string::npos : host_end - host_start);
-
-    if (host == k_steam_loopback) return true;
-    for (const auto* tld : k_steam_tlds) {
-        const size_t tld_len = std::strlen(tld);
-        if (host == tld) return true;
-        if (host.size() > tld_len + 1 && host[host.size() - tld_len - 1] == '.' && host.compare(host.size() - tld_len, tld_len, tld) == 0) return true;
-    }
-    return false;
-}
 
 bool webkit_world_mgr::is_valid_target_url(const std::string& url) const
 {
-    if (url.empty()) {
-        return false;
-    }
-
-    // only web protocols are supported
-    if (url.find("http://") != 0 && url.find("https://") != 0) {
-        return false;
-    }
-
-    // steamloopback is the main UI, handled natively by SharedJSContext
-    if (url.find("https://steamloopback.host/") == 0) {
-        return false;
-    }
-
-    // forbid URLs matching the global blacklist (e.g. checkout pages)
-    for (const auto& pattern : g_js_hook_blacklist) {
-        if (std::regex_match(url, pattern)) {
-            return false;
-        }
-    }
-
-    // allow all steam-owned popups/frames (e.g. store, community)
-    if (is_steam_owned_url(url)) {
-        return true;
-    }
-
-    // allow external URLs if explicitly hooked by a plugin or theme (e.g. via add_browser_js / add_browser_css in the backend)
-    const auto hookList = m_network_hook_ctl->get_hook_list();
-    return std::any_of(hookList.begin(), hookList.end(), [&url](const auto& hook)
-    {
-        return std::regex_match(url, hook.hook.url_pattern);
-    });
+    return target_url(url).allows_webkit_injection(m_network_hook_ctl->get_hook_list());
 }
 
 void webkit_world_mgr::attach_to_target(const std::string& target_id, const std::string& url)
@@ -190,7 +143,7 @@ void webkit_world_mgr::attach_to_target(const std::string& target_id, const std:
          * it seems this reload interferes with some versions of CF turnstile.
          */
         bool is_top_level = !frame_tree_result["frameTree"]["frame"].contains("parentId");
-        bool can_reload = is_top_level && is_steam_owned_url(url);
+        bool can_reload = is_top_level && target_url(url).is_steam_owned();
 
         {
             std::lock_guard<std::mutex> lock(m_targets_mutex);

--- a/src/engine/target_url.cc
+++ b/src/engine/target_url.cc
@@ -1,0 +1,106 @@
+#include "millennium/target_url.h"
+#include <curl/curl.h>
+#include <algorithm>
+#include <cctype>
+
+bool target_url::is_domain_match(std::string_view host, std::string_view domain) {
+    if (host == domain) return true;
+    if (host.length() > domain.length() && 
+        host[host.length() - domain.length() - 1] == '.' &&
+        host.ends_with(domain)) {
+        return true;
+    }
+    return false;
+}
+
+target_url::target_url(const std::string& url) : m_raw_url(url) {
+    CURLU* h = curl_url();
+    if (!h) return;
+
+    if (curl_url_set(h, CURLUPART_URL, url.c_str(), 0) == CURLUE_OK) {
+        char* host_ptr = nullptr;
+        char* scheme_ptr = nullptr;
+
+        if (curl_url_get(h, CURLUPART_HOST, &host_ptr, 0) == CURLUE_OK &&
+            curl_url_get(h, CURLUPART_SCHEME, &scheme_ptr, 0) == CURLUE_OK) {
+            
+            m_host = host_ptr;
+            m_scheme = scheme_ptr;
+
+            curl_free(host_ptr);
+            curl_free(scheme_ptr);
+
+            while (!m_host.empty() && m_host.back() == '.') {
+                m_host.pop_back();
+            }
+
+            std::transform(m_host.begin(), m_host.end(), m_host.begin(),
+                           [](unsigned char c){ return std::tolower(c); });
+            std::transform(m_scheme.begin(), m_scheme.end(), m_scheme.begin(),
+                           [](unsigned char c){ return std::tolower(c); });
+            
+            m_valid = true;
+        } else {
+            if (host_ptr) curl_free(host_ptr);
+            if (scheme_ptr) curl_free(scheme_ptr);
+        }
+    }
+    curl_url_cleanup(h);
+}
+
+target_url::~target_url() = default;
+
+bool target_url::is_valid() const {
+    return m_valid;
+}
+
+bool target_url::is_safe_for_network_hooks() const {
+    if (!m_valid) return false;
+    if (m_scheme != "http" && m_scheme != "https") return false;
+
+    static constexpr std::string_view forbidden_domains[] = {
+        "paypal.com", "paypalobjects.com", "recaptcha.net",
+        "youtube.com", "youtube-nocookie.com", "youtu.be", "ytimg.com", 
+        "googlevideo.com", "googleusercontent.com", "studioyoutube.com",
+        "chromewebstore.google.com"
+    };
+
+    for (const auto& domain : forbidden_domains) {
+        if (is_domain_match(m_host, domain)) return false;
+    }
+    return true;
+}
+
+bool target_url::is_safe_for_js() const {
+    if (!m_valid) return false;
+
+    if (is_domain_match(m_host, "checkout.steampowered.com")) {
+        return false;
+    }
+
+    return is_safe_for_network_hooks();
+}
+
+bool target_url::is_steam_owned() const {
+    if (!m_valid) return false;
+
+    if (m_host == k_steam_loopback) return true;
+
+    for (const auto* domain : k_steam_tlds) {
+        if (is_domain_match(m_host, domain)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool target_url::allows_webkit_injection(const std::vector<network_hook_ctl::hook_item>& hooks) const {
+    if (!m_valid) return false;
+    if (!is_safe_for_js()) return false;
+    if (m_host == k_steam_loopback) return false;
+    if (is_steam_owned()) return true;
+
+    return std::any_of(hooks.begin(), hooks.end(), [this](const auto& hook_item) {
+        return std::regex_match(m_raw_url, hook_item.hook.url_pattern);
+    });
+}

--- a/src/include/millennium/http_hooks.h
+++ b/src/include/millennium/http_hooks.h
@@ -48,11 +48,11 @@
 #include <unordered_map>
 #include <vector>
 
+
 extern std::atomic<unsigned long long> g_hookedModuleId;
 std::string get_cdp_isolated_ctx_script();
 
-/** Millennium will not load JavaScript into the following URLs (CSS injection is still allowed). */
-extern const std::vector<std::regex> g_js_hook_blacklist;
+
 
 /** Canonical list of Steam-owned TLDs. Both the CDP network interceptor and the webkit world manager derive their domain checks from this. */
 static constexpr const char* k_steam_tlds[] = {
@@ -62,6 +62,7 @@ static constexpr const char* k_steam_loopback = "steamloopback.host";
 /** Millennium will not hook the following URLs to favor user safety. (Neither JavaScript nor CSS will be injected into these URLs.) */
 extern const std::vector<std::regex> g_js_and_css_hook_blacklist;
 
+class target_url;
 class network_hook_ctl
 {
   public:
@@ -173,6 +174,6 @@ class network_hook_ctl
     void vfs_request_handler(const nlohmann::basic_json<>& message);
     void mime_doc_request_handler(const nlohmann::basic_json<>& message);
     std::filesystem::path path_from_url(const std::string& requestUrl);
-    processed_hooks apply_user_webkit_hooks(const std::string& requestUrl) const;
+    processed_hooks apply_user_webkit_hooks(const target_url& target) const;
     std::string inject_into_document_head(const std::string& original, const std::string& content) const;
 };

--- a/src/include/millennium/http_hooks.h
+++ b/src/include/millennium/http_hooks.h
@@ -52,15 +52,11 @@
 extern std::atomic<unsigned long long> g_hookedModuleId;
 std::string get_cdp_isolated_ctx_script();
 
-
-
 /** Canonical list of Steam-owned TLDs. Both the CDP network interceptor and the webkit world manager derive their domain checks from this. */
 static constexpr const char* k_steam_tlds[] = {
     "steampowered.com", "steamcommunity.com", "steamgames.com", "steam-chat.com", "steamstatic.com",
 };
 static constexpr const char* k_steam_loopback = "steamloopback.host";
-/** Millennium will not hook the following URLs to favor user safety. (Neither JavaScript nor CSS will be injected into these URLs.) */
-extern const std::vector<std::regex> g_js_and_css_hook_blacklist;
 
 class target_url;
 class network_hook_ctl

--- a/src/include/millennium/target_url.h
+++ b/src/include/millennium/target_url.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "millennium/http_hooks.h"
+
+class target_url {
+public:
+    explicit target_url(const std::string& url);
+    ~target_url();
+
+    // Was parsed successfully?
+    bool is_valid() const;
+
+    // Policy queries
+    bool is_safe_for_network_hooks() const;
+    bool is_safe_for_js() const;
+    bool is_steam_owned() const;
+    bool allows_webkit_injection(const std::vector<network_hook_ctl::hook_item>& hooks) const;
+
+    static bool is_domain_match(std::string_view host, std::string_view domain);
+
+    const std::string& scheme() const { return m_scheme; }
+    const std::string& host() const { return m_host; }
+    const std::string& raw_url() const { return m_raw_url; }
+
+private:
+    bool m_valid = false;
+    std::string m_scheme;
+    std::string m_host;
+    std::string m_raw_url;
+};

--- a/src/instrumentation/internal/steam_hooks.cc
+++ b/src/instrumentation/internal/steam_hooks.cc
@@ -44,7 +44,6 @@
 #include <unistd.h>
 #endif
 #include "millennium/filesystem.h" // IWYU pragma: keep
-
 #include "millennium/logger.h"
 #include "millennium/steam_hooks.h"
 #include "millennium/cmdline_api.h"

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(TEST_SOURCES
   ffi_recorder_test.cc
+  test_target_url.cc
   ${CMAKE_SOURCE_DIR}/src/mep/ffi_recorder.cc
+  ${CMAKE_SOURCE_DIR}/src/engine/target_url.cc
 )
 
 add_executable(millennium_cpp_tests ${TEST_SOURCES})
@@ -11,7 +13,7 @@ target_include_directories(millennium_cpp_tests PRIVATE
   ${CMAKE_SOURCE_DIR}/src/include
 )
 
-target_link_libraries(millennium_cpp_tests PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(millennium_cpp_tests PRIVATE Catch2::Catch2WithMain libcurl nlohmann_json::nlohmann_json)
 
 include(Catch)
 catch_discover_tests(millennium_cpp_tests)

--- a/tests/cpp/test_target_url.cc
+++ b/tests/cpp/test_target_url.cc
@@ -1,0 +1,108 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include "millennium/target_url.h"
+
+struct url_test_case {
+    std::string description;
+    std::string url;
+    bool expected_network_safe;
+    bool expected_js_safe;
+    bool expected_webkit_injection;
+};
+
+TEST_CASE("WebKit Target URL Validation", "[webkit]")
+{
+    SECTION("Domain Suffix Matching (is_domain_match)") {
+        // Exact matches
+        REQUIRE(target_url::is_domain_match("paypal.com", "paypal.com"));
+        REQUIRE(target_url::is_domain_match("youtube.com", "youtube.com"));
+
+        // Valid subdomains
+        REQUIRE(target_url::is_domain_match("www.paypal.com", "paypal.com"));
+        REQUIRE(target_url::is_domain_match("checkout.paypal.com", "paypal.com"));
+        REQUIRE(target_url::is_domain_match("a.b.c.paypal.com", "paypal.com"));
+
+        // Invalid partial matches (Spoofing attempts)
+        REQUIRE_FALSE(target_url::is_domain_match("fakepaypal.com", "paypal.com"));
+        REQUIRE_FALSE(target_url::is_domain_match("paypal.com.evil.com", "paypal.com"));
+        REQUIRE_FALSE(target_url::is_domain_match("mypaypal.com", "paypal.com"));
+    }
+
+    SECTION("Exhaustive URL Policies") {
+        auto test_case = GENERATE(
+            // Empty and Invalid URLs
+            url_test_case{"Empty URL", "", false, false, false},
+            url_test_case{"Invalid Scheme (ftp)", "ftp://store.steampowered.com", false, false, false},
+            url_test_case{"Invalid Scheme (file)", "file:///C:/Users/test/index.html", false, false, false},
+            url_test_case{"Invalid URL", "https://[::1]/", true, true, false},
+
+            // Native Steam Domains (Auto-Allowed)
+            url_test_case{"Storefront", "https://store.steampowered.com/", true, true, true},
+            url_test_case{"Community", "https://steamcommunity.com/id/someone", true, true, true},
+            url_test_case{"Steamgames HTTP", "http://steamgames.com/some/path", true, true, true},
+            
+            // Edge cases handled by libcurl
+            url_test_case{"Storefront with port", "https://store.steampowered.com:443/", true, true, true},
+            url_test_case{"Case-insensitive host", "https://STORE.STEAMPOWERED.COM/", true, true, true},
+            url_test_case{"Case-insensitive scheme", "HTTPS://STORE.STEAMPOWERED.COM/", true, true, true},
+            url_test_case{"Trailing dot", "https://store.steampowered.com./", true, true, true},
+            url_test_case{"Basic auth", "https://user:pass@steamcommunity.com/", true, true, true},
+
+            // Spoofed Native Steam Domains (Forbidden)
+            url_test_case{"Fake host prefix", "https://fakesteampowered.com/", true, true, false}, // Network safe, JS safe, but not steam owned so no injection
+            url_test_case{"Fake host suffix", "https://store.steampowered.com.evil.com/", true, true, false},
+
+            // Main UI (steamloopback) Forbidden
+            url_test_case{"Steam loopback", "https://steamloopback.host/index.html", true, true, false}, // Steam owned, but forbidden explicitly for injection
+
+            // Steam Checkout Blacklist (JS Forbidden, CSS Allowed)
+            url_test_case{"Steam checkout", "https://checkout.steampowered.com/pay", true, false, false},
+
+            // Global Network Blacklists (JS and CSS Forbidden)
+            url_test_case{"PayPal", "https://www.paypal.com/checkout", false, false, false},
+            url_test_case{"PayPal objects", "https://www.paypalobjects.com/webstatic/mktg/logo/pp_cc_mark_111x69.jpg", false, false, false},
+            url_test_case{"Recaptcha", "https://www.recaptcha.net/recaptcha/api.js", false, false, false},
+            url_test_case{"YouTube", "https://www.youtube.com/watch?v=dQw4w9WgXcQ", false, false, false},
+            url_test_case{"YouTube short", "https://youtu.be/dQw4w9WgXcQ", false, false, false},
+            url_test_case{"YouTube nocookie", "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ", false, false, false},
+            url_test_case{"YouTube images", "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg", false, false, false},
+            url_test_case{"Google Video", "https://r1---sn-a5mekner.googlevideo.com/videoplayback", false, false, false},
+            url_test_case{"Google user content", "https://yt3.googleusercontent.com/ytc/AIdro_m", false, false, false},
+            url_test_case{"YouTube Studio", "https://studioyoutube.com/", false, false, false},
+            url_test_case{"Chrome Web Store", "https://chromewebstore.google.com/detail/ublock-origin", false, false, false},
+
+            // Third-Party Domains (Forbidden by default)
+            url_test_case{"Cloudflare challenge", "https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/0/234", true, true, false},
+            url_test_case{"Google", "https://www.google.com/", true, true, false},
+            url_test_case{"Github", "https://github.com/SteamClientHomebrew/Millennium", true, true, false}
+        );
+
+        INFO("Testing URL: " << test_case.url << " (" << test_case.description << ")");
+        target_url target(test_case.url);
+        std::vector<network_hook_ctl::hook_item> empty_hooks;
+
+        REQUIRE(target.is_safe_for_network_hooks() == test_case.expected_network_safe);
+        REQUIRE(target.is_safe_for_js() == test_case.expected_js_safe);
+        REQUIRE(target.allows_webkit_injection(empty_hooks) == test_case.expected_webkit_injection);
+    }
+
+    SECTION("Third-Party Domains (Allowed if explicitly hooked)") {
+        std::vector<network_hook_ctl::hook_item> active_hooks;
+        network_hook_ctl::hook_item hook;
+        hook.hook.url_pattern = std::regex(".*discord\\.com.*");
+        active_hooks.push_back(hook);
+
+        target_url valid_hook("https://www.discord.com/app");
+        target_url invalid_hook("https://www.google.com/");
+
+        REQUIRE(valid_hook.allows_webkit_injection(active_hooks));
+        REQUIRE_FALSE(invalid_hook.allows_webkit_injection(active_hooks));
+    }
+
+    SECTION("Steam ownership vs injection") {
+        target_url loopback("https://steamloopback.host/index.html");
+        std::vector<network_hook_ctl::hook_item> empty_hooks;
+        REQUIRE(loopback.is_steam_owned());
+        REQUIRE_FALSE(loopback.allows_webkit_injection(empty_hooks));
+    }
+}


### PR DESCRIPTION
To prevent https://github.com/SteamClientHomebrew/Millennium/pull/803 happening again, I refactored the URL validation:
- Extracted validation logic into a class `target_url`
- Replaced the existing regex and string matching with libcurl (already imported so no added dependencies) for more robust URL parsing
- Added exhaustive testing to detect automatically if this breaks in future

I wanted to add ` ctest --test-dir build --output-on-failure -C Release` to the github actions ci.yml but I encountered unrelated test failures which would block build if merged https://github.com/BlythT/Millennium/actions/runs/27465672305 so I've reverted that