### PR TITLE
fix(nix): update Millennium to v3.3.0-beta.3 to resolve luajit build failure

### DIFF
--- a/packages/nix/flake.lock
+++ b/packages/nix/flake.lock
@@ -1,58 +1,40 @@
 {
   "nodes": {
-    "luajit-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1763177035,
-        "narHash": "sha256-oYD86MqmlJpiCuEs4LwVtxvarPtz1RPWm8nJqNE0sBs=",
-        "owner": "SteamClientHomebrew",
-        "repo": "LuaJIT",
-        "rev": "89550023569c3e195e75e12951c067fe5591e0d2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "SteamClientHomebrew",
-        "ref": "v2.1",
-        "repo": "LuaJIT",
-        "type": "github"
-      }
-    },
     "millennium-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1780800522,
-        "narHash": "sha256-Na2+zomNGTF2MPoX5Wm72MMi3dl+CQRtfFQHH0AT5JU=",
+        "lastModified": 1781998020,
+        "narHash": "sha256-B2U9CPsVrPnWtumMJxSZwhTHFxd5BGKvTZToQfNck3E=",
         "owner": "SteamClientHomebrew",
         "repo": "Millennium",
-        "rev": "bd79fe7a94aad1e840d8cae54d6b5233d80268a8",
+        "rev": "744de7d8a69592b8bdadad74e0e2b9b961e80c5f",
         "type": "github"
       },
       "original": {
         "owner": "SteamClientHomebrew",
         "repo": "Millennium",
-        "rev": "bd79fe7a94aad1e840d8cae54d6b5233d80268a8",
+        "rev": "744de7d8a69592b8bdadad74e0e2b9b961e80c5f",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770115704,
-        "narHash": "sha256-KHFT9UWOF2yRPlAnSXQJh6uVcgNcWlFqqiAZ7OVlHNc=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e6eae2ee2110f3d31110d5c222cd395303343b08",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "luajit-src": "luajit-src",
         "millennium-src": "millennium-src",
         "nixpkgs": "nixpkgs"
       }

--- a/packages/nix/flake.nix
+++ b/packages/nix/flake.nix
@@ -2,9 +2,10 @@
   description = "Nix Build for Millennium";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    # Bun FOD is sensitive to version changes, so we use a specific commit instead of a channel.
+    nixpkgs.url = "github:nixos/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f";
 
-    millennium-src.url   = "github:SteamClientHomebrew/Millennium/bd79fe7a94aad1e840d8cae54d6b5233d80268a8";
+    millennium-src.url   = "github:SteamClientHomebrew/Millennium/744de7d8a69592b8bdadad74e0e2b9b961e80c5f";
     millennium-src.flake = false;
 
   };

--- a/packages/nix/millennium.nix
+++ b/packages/nix/millennium.nix
@@ -10,7 +10,9 @@
   lib,
   stdenv,
   pkgsi686Linux,
-  xorg,
+  libx11,
+  libXi,
+  libXtst,
   re2,
   runCommand,
 
@@ -18,13 +20,12 @@
   ...
 }:
 let
-  version = "3.2.1-beta.1";
+  version = "3.3.0-beta.3";
 
   tsPackages = [
     "src/typescript/ttc"
     "src/typescript/sdk/packages/client"
     "src/typescript/sdk/packages/browser"
-    "src/typescript/sdk/packages/cdp-isolated-ctx"
     "src/typescript/sdk/packages/loader"
     "src/typescript/frontend"
   ];
@@ -80,7 +81,7 @@ let
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-XMYpHMrcmLNQYyLkc3DngjsZ4DdyPr9on0v5lcDrRiY=";
+    outputHash = "sha256-07kSANQ5uLwsLX+wuS0Cq2YSeTqkSVnUBGqadP0Uj4Y=";
   };
 
   build32 = pkgsi686Linux.stdenv.mkDerivation (commonBuild // {
@@ -137,9 +138,9 @@ let
     pname = "millennium-64";
 
     buildInputs = [
-      xorg.libX11
-      xorg.libXi
-      xorg.libXtst
+      libx11
+      libXi
+      libXtst
       re2
       re2.dev
     ];


### PR DESCRIPTION
Commit 0627f8cd2d4d47ca3ca0a066d9a3e77a67d782e1 desynced the `flake.nix` and `flake.lock`, resulting in Nix attempting to build the package with a version of Millennium where luajit isn't vendored and expected TypeScript packages were absent (`src/typescript/sdk/packages/cdp-isolated-ctx`).

**Changes:**
* Updates the flake input for Millennium to release `v3.3.0-beta.3` (744de7d8a69592b8bdadad74e0e2b9b961e80c5f).
* Updates `nixpkgs` to the latest unstable and pins it to that commit explicitly to make clear this package shouldn't arbitrarily follow the channel (see discussion in #551).
* Updates the `bun` FOD hash for `millennium-typescript-bun-deps` and removes the absent TypeScript package path.
* Updates deprecated `xorg` namespace packages to prevent build warnings.

**Testing:**
* Built all flake outputs successfully with a temporary store and only `cache.nixos.org` as the binary cache.
* Rebuilt local system using this branch and confirmed Steam successfully loads Millennium.
* Installed Extendium and a theme to verify everything works as expected.