### PR TITLE
fix(webkit): attach to middle-click open-in-new-tab Steam targets

### DIFF
--- a/src/engine/plugin_webkit_world_mgr.cc
+++ b/src/engine/plugin_webkit_world_mgr.cc
@@ -325,10 +325,18 @@ void webkit_world_mgr::target_create_hdlr(const json& params)
 
     const auto& target_info = params["targetInfo"];
     if (!target_info.contains("canAccessOpener") || !target_info.contains("url") || !target_info.contains("targetId")) return;
-    if (target_info["canAccessOpener"].get<bool>()) return;
 
     std::string url = target_info["url"].get<std::string>();
     std::string target_id = target_info["targetId"].get<std::string>();
+
+    /**
+     * Middle-click "open in new tab" Steam targets retain opener access
+     * (canAccessOpener == true). Skipping every opener-accessible target means
+     * such tabs never attach, so plugins don't load until a manual refresh.
+     * Only skip opener-accessible targets that are NOT Steam-owned, so external
+     * popups (e.g. Cloudflare-protected pages) are still left untouched.
+     */
+    if (target_info["canAccessOpener"].get<bool>() && !is_steam_owned_url(url)) return;
 
     if (!is_valid_target_url(url)) return;
     if (m_shutdown.load(std::memory_order_acquire)) return;
@@ -379,12 +387,17 @@ void webkit_world_mgr::target_change_hdlr(const json& params)
     std::string target_id = target_info["targetId"].get<std::string>();
     std::string url;
 
-    if (target_info.contains("canAccessOpener") && target_info["canAccessOpener"].get<bool>()) {
-        return;
-    }
-
     if (target_info.contains("url") && target_info["url"].is_string()) {
         url = target_info["url"].get<std::string>();
+    }
+
+    /**
+     * See target_create_hdlr: only skip opener-accessible targets that are NOT
+     * Steam-owned, so middle-click Steam tabs still attach while external
+     * popups remain untouched.
+     */
+    if (target_info.contains("canAccessOpener") && target_info["canAccessOpener"].get<bool>() && !is_steam_owned_url(url)) {
+        return;
     }
 
     if (!is_valid_target_url(url)) return;


### PR DESCRIPTION
## Problem

When a Steam profile (or any hooked Steam page) is opened via **middle-click → "open in new tab"**, plugins never load on that tab. The page console shows:

```
Refused to load the script 'https://millennium.ftp/.../millennium.js' because it violates the following Content Security Policy directive: "script-src 'self' ..."
Millennium failed to load webkit modules. TypeError: Failed to fetch dynamically imported module: https://millennium.ftp/.../millennium.js
```

A manual in-place refresh fixes it every time. Left-click / normal navigation also works. Only middle-click "open in new tab" is affected.

## Root cause

`target_create_hdlr` and `target_change_hdlr` early-return when `targetInfo.canAccessOpener == true`. A middle-click "open in new tab" target retains opener access, so Millennium never attaches to it, never calls `Page.setBypassCSP`, and never injects the SDK loader. Steam's CSP then refuses the `millennium.js` dynamic import.

## Fix

Instead of dropping the `canAccessOpener` guard entirely (which would also attach to external opener popups, e.g. Cloudflare-protected pages), only skip opener-accessible targets whose URL is **not** Steam-owned:

```cpp
if (target_info["canAccessOpener"].get<bool>() && !is_steam_owned_url(url)) return;
```

Middle-click Steam tabs are now attached and hooked like any other target, while external popups remain untouched. The reload-recovery path is already correctly gated by `is_steam_owned_url`, whose hostname/apex matching now lives upstream, so no change is needed there.

> Note: this supersedes the earlier two-commit version of this PR. The previous apex-matching fix for `is_steam_owned_url` is no longer needed — upstream now anchors that check to the hostname — so this PR is rebased onto current `main` as a single, focused change.

## Testing

Rebuilt from this branch via the existing `ci.yml` Windows job and swapped `millennium.dll` into a live install. Before: middle-clicked Steam profile tabs showed the CSP error above and never loaded the plugin until a manual refresh. After: the tab loads and the plugin renders automatically. Normal opens, manual refreshes, and external hooked pages are unaffected.