### PR TITLE
fix(arch): remove hardcoded `debug` option

### DIFF
--- a/packages/arch/PKGBUILD
+++ b/packages/arch/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainers: SteamClientHomebrew <https://github.com/SteamClientHomebrew>
+# Maintainer: SteamClientHomebrew <noreply@steambrew.app>
 
 pkgname="millennium"
 pkgver=3.3.0

--- a/packages/arch/PKGBUILD
+++ b/packages/arch/PKGBUILD
@@ -12,7 +12,6 @@ makedepends=('git' 'bun' 'curl' 'zip' 'unzip' 'tar' 'cmake' 'ninja' 'lib32-gcc-l
 install=millennium.install
 source=("git+$url.git#commit=948d3bb57f811d4bd9a1f43963defe73253a05bf")
 sha256sums=('SKIP')
-options=(debug)
 
 _pkgdir="Millennium"
 


### PR DESCRIPTION
The [PKGBUILD reference](https://wiki.archlinux.org/title/PKGBUILD#options) describes the `options` array as a way of “overriding some of the default behavior of *makepkg*, defined in `/etc/makepkg.conf`”. This means that setting `debug` here forces debug package creation even for users who have explicitly opted out via `!debug` in their global config.

A package should not silently override a deliberate user preference without a compelling technical reason. None exists here; `makepkg` handles debug packages correctly on its own when the user wants them.

---

I'd also like to kindly ask that you monitor the AUR comment section. The [AUR Submission Guidelines](https://wiki.archlinux.org/title/AUR_submission_guidelines#Maintaining_packages) explicitly state that maintainers should “check for feedback and comments from other users and try to incorporate any improvements they suggest”. Redirecting all discussion to GitHub excludes users without an account.

I raised this concern in the AUR comments on 2026-04-21 and again on 2026-06-08 with no response. Additionally, the [submission rules](https://wiki.archlinux.org/title/AUR_submission_guidelines#Rules_of_submission) ask that the maintainer header include a contact email address, which is currently missing from this PKGBUILD.