### PR TITLE
feat: add SteamRT3 client incompatibility warning check

### DIFF
--- a/packages/arch/millennium.install
+++ b/packages/arch/millennium.install
@@ -16,6 +16,28 @@ remove_deprecated_patches() {
     fi
 }
 
+# Warn the user if the experimental 64-bit client is enabled
+check_steamrt3_incompatibility() {
+    local steam="/home/$(logname)/.local/share/Steam"
+    local -a required_markers=(
+        "$steam/package/beta"
+        "$steam/.steam-enable-steamrt64-client"
+        "$steam/steamrt64/steam"
+    )
+
+    for marker in "${required_markers[@]}"; do
+        [[ -f "$marker" ]] || return 0
+    done
+
+    echo -e "\e[1;33m"
+    echo -e "\n  WARNING: SteamRT3 client detected\n"
+    echo -e "  Millennium does not support the experimental SteamRT3 client."
+    echo -e "  For Millennium to work correctly, please either:"
+    echo -e "  - disable the \"Use experimental SteamRT3 Steam Client\" option"
+    echo -e "  - opt out of the Steam Beta entirely\n"
+    echo -e "\e[0m"
+}
+
 for_each_steam_user() {
     local callback="$1"
     getent passwd | while IFS=: read -r _ _ uid _ _ home _; do

--- a/packages/nix/steam.nix
+++ b/packages/nix/steam.nix
@@ -24,7 +24,7 @@ let
 
   steamrt3Check = ''
     check_steamrt3_incompatibility() {
-        local steam="/home/$(logname)/.local/share/Steam"
+        local steam="$HOME/.local/share/Steam"
         local -a required_markers=(
             "$steam/package/beta"
             "$steam/.steam-enable-steamrt64-client"

--- a/packages/nix/steam.nix
+++ b/packages/nix/steam.nix
@@ -22,9 +22,36 @@ let
     MILLENNIUM_RUNTIME_PATH = "${millennium}/lib/libmillennium_x86.so";
   };
 
+  steamrt3Check = ''
+    check_steamrt3_incompatibility() {
+        local steam="/home/$(logname)/.local/share/Steam"
+        local -a required_markers=(
+            "$steam/package/beta"
+            "$steam/.steam-enable-steamrt64-client"
+            "$steam/steamrt64/steam"
+        )
+
+        for marker in "''${required_markers[@]}"; do
+            [[ -f "$marker" ]] || return 0
+        done
+
+        echo -e "\e[1;33m"
+        echo -e "\n  WARNING: SteamRT3 client detected\n"
+        echo -e "  Millennium does not support the experimental SteamRT3 client."
+        echo -e "  For Millennium to work correctly, please either:"
+        echo -e "  - disable the \"Use experimental SteamRT3 Steam Client\" option"
+        echo -e "  - opt out of the Steam Beta entirely\n"
+        echo -e "\e[0m"
+    }
+
+    check_steamrt3_incompatibility
+  '';
+
   millenniumProfile = ''
     ln -sf ${millennium}/lib/libmillennium_bootstrap_x86.so "$HOME/.local/share/Steam/ubuntu12_32/libXtst.so.6"
     ln -sf ${millennium}/lib/libmillennium_bootstrap_hhx64.so "$HOME/.local/share/Steam/ubuntu12_64/libXtst.so.6"
+
+    ${steamrt3Check}
   '';
 
   upstreamArgs = removeAttrs args [

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -171,6 +171,25 @@ install_millennium() {
     fi
 }
 
+check_steamrt3_incompatibility() {
+    local -a required_markers=(
+        "${HOME}/.steam/steam/.steam-enable-steamrt64-client"
+        "${HOME}/.steam/steam/steamrt64/steam"
+    )
+
+    for marker in "${required_markers[@]}"; do
+        [[ -f "$marker" ]] || return 0
+    done
+
+    echo -e "\e[1;33m"
+    echo -e "\n  WARNING: SteamRT3 client detected\n"
+    echo -e "  Millennium does not support the experimental SteamRT3 client."
+    echo -e "  For Millennium to work correctly, please either:"
+    echo -e "  - disable the \"Use experimental SteamRT3 Steam Client\" option"
+    echo -e "  - opt out of the Steam Beta entirely\n"
+    echo -e "\e[0m"
+}
+
 post_install() {
     sudo chmod +x /usr/lib/millennium/libmillennium_pvs64 2>/dev/null || true
     sudo chmod +x /usr/lib/millennium/libmillennium_luavm_x86 2>/dev/null || true
@@ -193,6 +212,9 @@ post_install() {
     ln -sf /usr/lib/millennium/libmillennium_bootstrap_x86.so   "${HOME}/.steam/steam/ubuntu12_32/libXtst.so.6"
     ln -sf /usr/lib/millennium/libmillennium_bootstrap_hhx64.so "${HOME}/.steam/steam/ubuntu12_64/libXtst.so.6"
     ln -sf /usr/lib/millennium/libmillennium_hhx64.so           "${HOME}/.steam/steam/ubuntu12_64/libmillennium_hhx64.so"
+
+    # check for unsupported 64-bit steam client
+    check_steamrt3_incompatibility
 }
 
 cleanup() {


### PR DESCRIPTION
## Detect unsupported SteamRT3 client and warn at install time

Closes #840 

### What this does

Adds a `check_steamrt3_incompatibility` function that runs after installing to warn the user when Steam is using the SteamRT3 (64-bit) experimental client, since the current preload hook targets the 32-bit client process (`ubuntu12_32/libXtst.so.6`) which RT3 never launches.

As described in the linked issue, without this check the install completes silently and the user has no way to tell "broken install" from "unsupported client".

### Detection logic

Detection is done via three on-disk markers that together indicate an active RT3 session:

- `$STEAM/package/beta` - beta channel is active
- `$STEAM/.steam-enable-steamrt64-client` - RT3 experimental toggle is on
- `$STEAM/steamrt64/steam` - the 64-bit client binary is present

All three must exist for the warning to fire, which avoids false positives on a stable/32-bit install.

### Where it's wired in

- **`.install`** (AUR/pacman hook) - `post_install()` calls the check.
- **`install.sh`** (Other distributions) - same check ported to the shell installer.
- **Nix module** - added to `extraProfile` alongside the existing symlink logic, so it runs in the same shell context where `$HOME` is already correctly resolved for the logged-in user.

Install still proceeds either way - this is a warning, not a hard block, per the discussion in the issue.

### Sample output

```
  WARNING: SteamRT3 client detected

  Millennium does not support the experimental/beta SteamRT3 client.
  For Millennium to work correctly, please either:
  - disable the "Use experimental SteamRT3 Steam Client" option
  - opt out of the Steam Beta entirely
```

### Testing

Tested on Arch with Steam `publicbeta` + RT3 experimental enabled (the environment from the original issue) - warning fires correctly post-install.