### PR TITLE
fix(frontend): support Steam beta root menu

### DIFF
--- a/src/typescript/frontend/patcher/index.ts
+++ b/src/typescript/frontend/patcher/index.ts
@@ -172,7 +172,7 @@ export async function onWindowCreatedCallback(windowContext: any): Promise<void>
 
 	/** Patch the steam root menu to add the Millennium root menu */
 	if (windowTitle === 'Steam Root Menu') {
-		PatchRootMenu();
+		PatchRootMenu(windowContext.window.document);
 	}
 
 	const prevMainWindow = pluginSelf.mainWindow;

--- a/src/typescript/frontend/settings/index.tsx
+++ b/src/typescript/frontend/settings/index.tsx
@@ -210,8 +210,14 @@ export function MillenniumSettings() {
 	);
 }
 
-function RenderSettingsModal(_: any, retObj: any) {
-	const items = [
+export type SettingsMenuItem = 'separator' | {
+	name: string;
+	onClick: () => void;
+	visible: boolean;
+};
+
+export function GetSettingsMenuItems(): SettingsMenuItem[] {
+	return [
 		{
 			name: locale.strMillennium,
 			onClick: () => {
@@ -228,6 +234,10 @@ function RenderSettingsModal(_: any, retObj: any) {
 		},
 		'separator',
 	];
+}
+
+function RenderSettingsModal(_: any, retObj: any) {
+	const items = GetSettingsMenuItems();
 
 	retObj?.props?.menuItems?.splice?.(retObj?.props?.menuItems?.length - 1, 0, ...items);
 	return retObj?.type?.(retObj.props);

--- a/src/typescript/frontend/utils/root-menu.ts
+++ b/src/typescript/frontend/utils/root-menu.ts
@@ -28,15 +28,89 @@
  * SOFTWARE.
  */
 
-import { afterPatch, findInReactTree, getReactRoot } from '@steambrew/sdk';
-import { RenderSettingsModal } from '../settings';
+import { afterPatch, findInReactTree, getReactInstance, getReactRoot } from '@steambrew/sdk';
+import { GetSettingsMenuItems, RenderSettingsModal } from '../settings';
 
-export function PatchRootMenu() {
-	const steamRootMenu = findInReactTree(getReactRoot(document.getElementById('root') as any), (m) => {
-		return m?.pendingProps?.title === 'Steam' && m?.pendingProps?.menuContent;
+const ROOT_MENU_ITEM_ATTRIBUTE = 'data-millennium-root-menu-item';
+
+function settingsItemsAreRendered(renderedItems: HTMLElement[]) {
+	const renderedItemNames = new Set(renderedItems.map((item) => item.textContent));
+	return GetSettingsMenuItems().every((item) => {
+		return item === 'separator' || !item.visible || renderedItemNames.has(item.name);
 	});
+}
 
-	if (steamRootMenu?.pendingProps?.menuContent) {
-		afterPatch(steamRootMenu.pendingProps.menuContent, 'type', RenderSettingsModal);
+function removeRenderedRootMenuFallback(document: Document) {
+	document.querySelectorAll(`[${ROOT_MENU_ITEM_ATTRIBUTE}]`).forEach((item) => item.remove());
+}
+
+function getRootMenuReactTree(document: Document) {
+	const legacyRoot = document.getElementById('root');
+	const legacyReactRoot = legacyRoot ? getReactRoot(legacyRoot) : undefined;
+	if (legacyReactRoot) return legacyReactRoot;
+
+	/** Steam beta mounts popup React trees below #popup_target instead of #root. */
+	const popupRoot = document.querySelector('#popup_target > *');
+	let popupFiber = popupRoot ? getReactInstance(popupRoot) : undefined;
+	while (popupFiber?.return) popupFiber = popupFiber.return;
+	return popupFiber;
+}
+
+function patchRenderedRootMenu(document: Document) {
+	if (document.querySelector(`[${ROOT_MENU_ITEM_ATTRIBUTE}]`)) return;
+
+	const renderedItems = Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+	if (settingsItemsAreRendered(renderedItems)) return;
+
+	const exitItem = renderedItems.at(-1);
+	const menuContainer = exitItem?.parentElement;
+	if (!exitItem || !menuContainer) return;
+
+	const separatorTemplate = exitItem.previousElementSibling;
+	for (const item of GetSettingsMenuItems()) {
+		if (item === 'separator') {
+			if (separatorTemplate?.tagName === 'HR') {
+				const separator = separatorTemplate.cloneNode(false) as HTMLElement;
+				separator.setAttribute(ROOT_MENU_ITEM_ATTRIBUTE, 'separator');
+				menuContainer.insertBefore(separator, exitItem);
+			}
+			continue;
+		}
+		if (!item.visible) continue;
+
+		const menuItem = exitItem.cloneNode(false) as HTMLElement;
+		menuItem.textContent = item.name;
+		menuItem.setAttribute(ROOT_MENU_ITEM_ATTRIBUTE, item.name);
+		menuItem.addEventListener('click', item.onClick);
+		menuContainer.insertBefore(menuItem, exitItem);
+	}
+
+	/** Drop the fallback if a later Steam render applies the React patch. */
+	const observer = new MutationObserver(() => {
+		const reactItems = Array.from(
+			document.querySelectorAll<HTMLElement>(`[role="menuitem"]:not([${ROOT_MENU_ITEM_ATTRIBUTE}])`),
+		);
+		if (!settingsItemsAreRendered(reactItems)) return;
+		removeRenderedRootMenuFallback(document);
+		observer.disconnect();
+	});
+	observer.observe(document.body, { childList: true, subtree: true });
+}
+
+export async function PatchRootMenu(document: Document) {
+	/** The popup document may be reported just before React mounts its first child. */
+	for (let attempt = 0; attempt < 20; attempt++) {
+		const steamRootMenu = findInReactTree(getRootMenuReactTree(document), (m) => {
+			return m?.pendingProps?.title === 'Steam' && m?.pendingProps?.menuContent;
+		});
+
+		if (steamRootMenu?.pendingProps?.menuContent) {
+			afterPatch(steamRootMenu.pendingProps.menuContent, 'type', RenderSettingsModal);
+			await new Promise((resolve) => setTimeout(resolve, 100));
+			patchRenderedRootMenu(document);
+			return;
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, 100));
 	}
 }


### PR DESCRIPTION
## Summary
- discover the Steam root menu React tree from either the legacy `#root` mount or the current beta `#popup_target` mount
- retry briefly while the popup React tree is mounting
- retain the normal React patch and add a cached-render fallback for Steam beta popups
- reuse the same localized menu item definitions and remove fallback nodes if a later React render takes over

## Problem
Steam public beta build `1786141909` pre-renders and reuses the root-menu popup below `#popup_target`. Millennium's `getReactRoot(document.getElementById('root'))` lookup therefore returns no tree, leaving the backend and plugins loaded but the Millennium menu unavailable.

## Testing
- `bun run typecheck` in `src/typescript/frontend`
- complete Windows release build with CMake/MSVC
- live-tested on Steam public beta build `1786141909`
- verified one Millennium menu pair, Settings navigation, menu persistence after reopening, and successful backend/frontend plugin loading